### PR TITLE
Check if mimetype command exists

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -155,7 +155,7 @@ function uploadFile(){
 	SLUG=`basename "$FILE"`
 	FILENAME="${SLUG%.*}"
 	EXTENSION="${SLUG##*.}"
-	if [ "$FILENAME" == "$EXTENSION" ]
+	if [ "$FILENAME" == "$EXTENSION" -o ! "$(command -v mimetype)" ]
    	then
      		MIME_TYPE=`file --brief --mime-type "$FILE"`
    	else


### PR DESCRIPTION
`mimetype` is not present on a minimal arch linux installation