### PR TITLE
Fixes #5 curl error and "root folder id" check

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -182,7 +182,7 @@ function uploadFile(){
 				-H "X-Upload-Content-Length: $FILESIZE" \
 				-d "$postData" \
 				"https://www.googleapis.com/upload/drive/v2/files?uploadType=resumable" \
-				--dump-header - | sed -ne s/"Location: "//p | tr -d '\r\n'`
+				--dump-header - | sed -ne s/"Location: "//pi | tr -d '\r\n'`
 
 	# Curl command to push the file to google drive.
 	# If the file size is large then the content can be split to chunks and uploaded.
@@ -211,7 +211,7 @@ then
     		ROOT_FOLDER="root"
     		echo "ROOT_FOLDER=$ROOT_FOLDER" >> $HOME/.googledrive.conf
     	else
-		    if expr "$ROOT_FOLDER" : '^[A-Za-z0-9_]\{28\}$' > /dev/null
+		    if expr "$ROOT_FOLDER" : '^[A-Za-z0-9_-]\{28\}$' > /dev/null
 		    then
 				echo "ROOT_FOLDER=$ROOT_FOLDER" >> $HOME/.googledrive.conf
 			else


### PR DESCRIPTION
Fixes #5 curl "<url> malformed" error: made sed case-insensitive when searching for "Location: ".  The fix proposed by @irremotus works fine too, but allowing for both is a more flexible approach.

Fixes unreported bug with the "root folder id" check:  added the hyphen as an allowed character.  I discovered this because my chosen root folder ID does have a hyphen in it, and the upload.sh  script rejected it.