### PR TITLE
Feature teams

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -344,7 +344,7 @@ driveInfo() {
         --silent \
         -XGET \
         -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-        "https://www.googleapis.com/drive/v3/files/""$FOLDER_ID""?fields=""$FETCH""")"
+        "https://www.googleapis.com/drive/v3/files/""$FOLDER_ID""?fields=""$FETCH""&supportsAllDrives=true")"
     local FETCHED_DATA
     FETCHED_DATA="$(echo "$SEARCH_RESPONSE" | jsonValue "$FETCH" 1)"
     if [ -z "$FETCHED_DATA" ]; then

--- a/upload.sh
+++ b/upload.sh
@@ -377,7 +377,7 @@ createDirectory() {
         --silent \
         -XGET \
         -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-        "https://www.googleapis.com/drive/v3/files?q=${QUERY}&fields=files(id)")"
+        "https://www.googleapis.com/drive/v3/files?q=${QUERY}&fields=files(id)&supportsAllDrives=true")"
     local FOLDER_ID
     FOLDER_ID="$(echo "$SEARCH_RESPONSE" | jsonValue id 1)"
     if [ -z "$FOLDER_ID" ]; then
@@ -390,7 +390,7 @@ createDirectory() {
             -H "Authorization: Bearer ${ACCESS_TOKEN}" \
             -H "Content-Type: application/json; charset=UTF-8" \
             -d "$CREATE_FOLDER_POST_DATA" \
-            "https://www.googleapis.com/drive/v3/files?fields=id")"
+            "https://www.googleapis.com/drive/v3/files?fields=id&supportsAllDrives=true")"
         FOLDER_ID="$(echo "$CREATE_FOLDER_RESPONSE" | jsonValue id)"
     fi
     echo "$FOLDER_ID"


### PR DESCRIPTION
I tried getting uploads to Team Drives to work, but I couldn't. It doesn't work because driveInfo() fails when trying to confirm the ID exists. I played in the Google API explorer and confirmed that it also needs `supportsAllDrives=true` Which is weird since PR #21 from @frankent mentions Team Suport so at least then it should have worked.

Anyways with this little fixes I can upload and create folders using a teams folder ID as root. 

Funny enough this will not be required after June 1, 2020. According to https://developers.google.com/drive/api/v3/enable-shareddrives those parameters will go away and be assumed true. 