### PR TITLE
install.sh|upload.sh: Parse arguments without getopts | Improve input fle/folder parsing | Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
   - [First Run](#first-run)
   - [Upload](#upload)
   - [Custom Flags](#custom-flags)
+  - [Multiple Inputs](#multiple-inputs)
   - [Resuming Interrupted Uploads](#resuming-interrupted-uploads)
 - [Uninstall](#Uninstall)
 - [Reporting Issues](#reporting-issues)
@@ -412,6 +413,38 @@ These are the custom flags that are currently implemented:
 -   <strong>-D | --debug</strong>
 
     Display script command trace.
+
+    ---
+
+### Multiple Inputs
+
+For using multiple inputs at a single time, you can use the `-f/--file/--folder` flag as explained above.
+
+Now, to achieve multiple inputs without flag, it gets a little tricky. Some of them are explained below along with other usecases.
+
+e.g:
+
+-   <strong>gupload a b `or` gupload -d -o -D a b</strong>
+
+    a is file/folder and b is gdrive_folder
+
+    ---
+
+-   <strong>gupload -d -o a b c d -d</strong>
+
+    a,b,c and d are file/folder. Using multiple inputs with -f flag.
+
+    ---
+
+-   <strong>gupload a b -d c d</strong>
+
+    a and c are file/folder but b and d are gdrive folder, but since d is given at last, it will taken as gdrive folder.
+
+    ---
+
+-   <strong>gupload a b -d -o c d e</strong>
+
+    a, c, d and e is file/folder and b is gdrive_folder
 
     ---
 

--- a/utils.sh
+++ b/utils.sh
@@ -210,10 +210,13 @@ _extract_id() {
 # Result: print full path
 ###################################################
 _full_path() {
-    case "${1?${FUNCNAME[0]}: Missing arguments}" in
-        /*) printf "%s\n" "${1}" ;;
-        *) printf "%s\n" "${PWD}/${1}" ;;
-    esac
+    [[ $# = 0 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
+    declare input="${1}"
+    if [[ -f ${input} ]]; then
+        printf "%s/%s\n" "$(cd "$(_dirname "${input}")" && pwd)" "${input##*/}"
+    elif [[ -d ${input} ]]; then
+        printf "%s\n" "$(cd "${input}" && pwd)"
+    fi
 }
 
 ###################################################
@@ -263,7 +266,6 @@ _is_terminal() {
 # Result: print extracted value
 ###################################################
 _json_value() {
-    [[ $# = 0 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
     declare LC_ALL=C num="${2:-1}"
     grep -o "\"""${1}""\"\:.*" | sed -e "s/.*\"""${1}""\": //" -e 's/[",]*$//' -e 's/["]*$//' -e 's/[,]*$//' -e "s/\"//" -n -e "${num}"p
 }


### PR DESCRIPTION


e.g: gupload -d -o a b, here a is file/folder, b is gdrive folder.

   : gupload a b, here a is file/folder, b is gdrive folder.

   : gupload -d -o a b -s c d, here a, b and c are file/folder, d is gdrive folder.

* _json_value: Don't check for arguments

    because it works on pipe output too

* _full_path: Improve the function for various usescases, make it more accurate

* fix some typos

* Update README