### PR TITLE
Fix sync script for empty folders | Resolve #72 | Check dependencies in install.sh | Do not use github api to fetch sha/tag | Allow syncing to root folder with sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ You can install the script by automatic installation script provided in the repo
 
 This will also install the synchronisation script provided in the repo.
 
+Installation script also checks for the native dependencies.
+
 Default values set by automatic installation script, which are changeable:
 
 **Repo:** `labbots/google-drive-upload`

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ Here, folder_name is the local folder you want to sync and gdrive_folder is goog
 
 In the local folder, all the contents present or added in the future will be automatically uploaded.
 
-Note: Giving gdrive_folder is optional, if you don't specify a name with -d/--directory flags, then it will take the name of the local folder.
+Note: Giving gdrive_folder is optional, if you don't specify a name with -d/--directory flags, then it will upload in the root folder set by gupload command.
 
 Also, gdrive folder creation works in the same way as gupload command.
 

--- a/google-oauth2.sh
+++ b/google-oauth2.sh
@@ -79,8 +79,8 @@ if [[ ${1} = create ]]; then
     if [[ -n ${CODE} ]]; then
         RESPONSE="$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" ${TOKEN_URL})"
 
-        ACCESS_TOKEN="$(_json_value access_token <<< "${RESPONSE}")"
-        REFRESH_TOKEN="$(_json_value refresh_token <<< "${RESPONSE}")"
+        ACCESS_TOKEN="$(_json_value access_token 1 1 <<< "${RESPONSE}")"
+        REFRESH_TOKEN="$(_json_value refresh_token 1 1 <<< "${RESPONSE}")"
 
         if [[ -n ${ACCESS_TOKEN} && -n ${REFRESH_TOKEN} ]]; then
             "${UPDATE:-:}" REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG:-${HOME}/.googledrive.conf}"
@@ -102,8 +102,8 @@ elif [[ ${1} = refresh ]]; then
     # Requirements: Refresh Token
     _get_token_and_update() {
         RESPONSE="$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")"
-        ACCESS_TOKEN="$(_json_value access_token <<< "${RESPONSE}")"
-        ACCESS_TOKEN_EXPIRY="$(curl --compressed -s "${API_URL}/oauth2/${API_VERSION}/tokeninfo?access_token=${ACCESS_TOKEN}" | _json_value exp)"
+        ACCESS_TOKEN="$(_json_value access_token 1 1 <<< "${RESPONSE}")"
+        ACCESS_TOKEN_EXPIRY="$(curl --compressed -s "${API_URL}/oauth2/${API_VERSION}/tokeninfo?access_token=${ACCESS_TOKEN}" | _json_value exp 1 1)"
         "${UPDATE:-:}" ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
         "${UPDATE:-:}" ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
     }

--- a/sync.sh
+++ b/sync.sh
@@ -191,8 +191,11 @@ _check_and_upload() {
 
     mapfile -t all <<< "$(printf "%s\n%s\n" "$(< "${SUCCESS_LOG}")" "$(< "${ERROR_LOG}")")"
     # check if folder is empty
-    { all+=(*) && [[ ${all[1]} = "*" ]] && return 0; } || :
-
+    if [[ $(printf "%b\n" ./*) = "./*" ]]; then
+        return 0
+    else
+        all+=(*)
+    fi
     mapfile -t final <<< "$(_remove_array_duplicates "${all[@]}")"
 
     mapfile -t new_files <<< "$(diff \
@@ -363,9 +366,6 @@ _setup_arguments() {
     SYNC_DETAIL_DIR="${INFO_PATH}/sync"
     SYNC_LIST="${SYNC_DETAIL_DIR}/sync_list"
     mkdir -p "${SYNC_DETAIL_DIR}" && printf "" >> "${SYNC_LIST}"
-
-    # Grab the first arg and shift, only if ${1} doesn't contain -.
-    { ! [[ ${1} = -* ]] && INPUT_ARRAY+=("${1}") && shift; } || :
 
     _check_longoptions() {
         { [[ -z ${2} ]] &&

--- a/sync.sh
+++ b/sync.sh
@@ -208,7 +208,7 @@ _check_and_upload() {
         printf "" >| "${ERROR_LOG}"
         for new_file in "${new_files[@]}"; do
             # shellcheck disable=SC2086
-            if "${COMMAND_NAME}" "${new_file}" ${ARGS} -C "${GDRIVE_FOLDER}"; then
+            if "${COMMAND_NAME}" "${new_file}" ${ARGS}; then
                 printf "%s\n" "${new_file}" >> "${SUCCESS_LOG}"
             else
                 printf "%s\n" "${new_file}" >> "${ERROR_LOG}"
@@ -385,6 +385,7 @@ _setup_arguments() {
             -d | --directory)
                 _check_longoptions "${1}" "${2}"
                 GDRIVE_FOLDER="${2}" && shift
+                ARGS+=" -C ${GDRIVE_FOLDER} "
                 ;;
             -j | --jobs)
                 { [[ ${2} = v* ]] && SHOW_JOBS_VERBOSE="true" && shift; } || :
@@ -519,7 +520,7 @@ _process_arguments() {
     for INPUT in "${FINAL_INPUT_ARRAY[@]}"; do
         CURRENT_FOLDER="$(pwd)"
         FOLDER="$(cd "${INPUT}" && pwd)" || exit 1
-        GDRIVE_FOLDER="${GDRIVE_FOLDER:-${FOLDER##*/}}"
+        GDRIVE_FOLDER="${GDRIVE_FOLDER:-${ROOT_FOLDER_NAME}}"
         cd "${FOLDER}" || exit 1
         _check_existing_loop
         status="$?"

--- a/utils.sh
+++ b/utils.sh
@@ -87,28 +87,21 @@ _check_debug() {
 ###################################################
 # Check internet connection.
 # Probably the fastest way, takes about 1 - 2 KB of data, don't check for more than 10 secs.
-# Use alternate timeout method if possible, as curl -m option is unreliable in some cases.
 # Globals: 2 functions
 #   _print_center, _clear_line
 # Arguments: None
 # Result: On
 #   Success - Nothing
 #   Error   - print message and exit 1
-# Reference:
-#   Alternative to timeout command: https://unix.stackexchange.com/a/18711
 ###################################################
 _check_internet() {
     _print_center "justify" "Checking Internet Connection.." "-"
-    if _is_terminal; then
-        CHECK_INTERNET="$(sh -ic 'exec 3>&1 2>/dev/null; { curl --compressed -Is google.com 1>&3; kill 0; } | { sleep 10; kill 0; }' || :)"
-    else
-        CHECK_INTERNET="$(curl --compressed -Is google.com -m 10)"
-    fi
-    _clear_line 1
-    if [[ -z ${CHECK_INTERNET} ]]; then
+    if ! _timeout 10 curl -Is google.com; then
+        _clear_line 1
         printf "Error: Internet connection not available.\n"
         exit 1
     fi
+    _clear_line 1
 }
 
 ###################################################
@@ -214,9 +207,9 @@ _extract_id() {
     [[ $# = 0 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
     declare LC_ALL=C ID="${1//[[:space:]]/}"
     case "${ID}" in
-        *'drive.google.com'*'id='*) ID="${ID/*id=/}" && ID="${ID/[?,&]*/}" ;;
-        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) ID="${ID/*\/d\//}" && ID="${ID/\/*/}" && ID="${ID/[?,&]*/}" ;;
-        *'drive.google.com'*'drive'*'folders'*) ID="${ID/*\/folders\//}" && ID="${ID/[?,&]*/}" ;;
+        *'drive.google.com'*'id='*) ID="${ID/*id=/}" && ID="${ID//[?&]*/}" ;;
+        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) ID="${ID/*\/d\//}" && ID="${ID/\/*/}" && ID="${ID//[?&]*/}" ;;
+        *'drive.google.com'*'drive'*'folders'*) ID="${ID/*\/folders\//}" && ID="${ID//[?&]*/}" ;;
     esac
     printf "%s\n" "${ID}"
 }
@@ -233,9 +226,9 @@ _full_path() {
     [[ $# = 0 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
     declare input="${1}"
     if [[ -f ${input} ]]; then
-        printf "%s/%s\n" "$(cd "$(_dirname "${input}")" && pwd)" "${input##*/}"
+        printf "%s/%s\n" "$(cd "$(_dirname "${input}")" &> /dev/null && pwd)" "${input##*/}"
     elif [[ -d ${input} ]]; then
-        printf "%s\n" "$(cd "${input}" && pwd)"
+        printf "%s\n" "$(cd "${input}" &> /dev/null && pwd)"
     fi
 }
 
@@ -253,13 +246,13 @@ _get_latest_sha() {
     declare LATEST_SHA
     case "${1:-${TYPE}}" in
         branch)
-            LATEST_SHA="$(curl --compressed -s https://api.github.com/repos/"${3:-${REPO}}"/commits/"${2:-${TYPE_VALUE}}" | _json_value sha)"
+            LATEST_SHA="$(curl --compressed -s https://api.github.com/repos/"${3:-${REPO}}"/commits/"${2:-${TYPE_VALUE}}" | _json_value sha 1 1)"
             ;;
         release)
-            LATEST_SHA="$(curl --compressed -s https://api.github.com/repos/"${3:-${REPO}}"/releases/"${2:-${TYPE_VALUE}}" | _json_value tag_name)"
+            LATEST_SHA="$(curl --compressed -s https://api.github.com/repos/"${3:-${REPO}}"/releases/"${2:-${TYPE_VALUE}}" | _json_value tag_name 1 1)"
             ;;
     esac
-    echo "${LATEST_SHA}"
+    printf "%s\n" "${LATEST_SHA}"
 }
 
 ###################################################
@@ -278,7 +271,8 @@ _is_terminal() {
 # Globals: None
 # Arguments: 2
 #   ${1} - value of field to fetch from json
-#   ${2} - Optional, nth number of value from extracted values, default it 1.
+#   ${2} - Optional, no of lines to parse for the given field in 1st arg
+#   ${3} - Optional, nth number of value from extracted values, default it 1.
 # Input: file | here string | pipe
 #   _json_value "Arguments" < file
 #   _json_value "Arguments <<< "${varibale}"
@@ -287,8 +281,9 @@ _is_terminal() {
 ###################################################
 _json_value() {
     declare LC_ALL=C num
-    { [[ ${2} != all ]] && num=1; } || :
-    grep -o "\"""${1}""\"\:.*" | sed -e "s/.*\"""${1}""\": //" -e 's/[",]*$//' -e 's/["]*$//' -e 's/[,]*$//' -e "s/\"//" -n -e "${num}"p
+    { [[ ${2} =~ ^([0-9]+)+$ ]] && no_of_lines="${2}"; } || :
+    { [[ ${3} =~ ^([0-9]+)+$ ]] && num="${3}"; } || { [[ ${3} != all ]] && num=1; }
+    grep -o "\"${1}\"\:.*" ${no_of_lines:+-m ${no_of_lines}} | sed -e "s/.*\"""${1}""\"://" -e 's/[",]*$//' -e 's/["]*$//' -e 's/[,]*$//' -e "s/^ //" -e 's/^"//' -n -e "${num}"p
 }
 
 ###################################################
@@ -322,8 +317,8 @@ _print_center() {
         justify)
             if [[ $# = 3 ]]; then
                 declare input1="${2}" symbol="${3}" TO_PRINT out
-                TO_PRINT="$((TERM_COLS * 95 / 100))"
-                { [[ ${#input1} -gt ${TO_PRINT} ]] && out="[ ${input1:0:TO_PRINT}.. ]"; } || { out="[ ${input1} ]"; }
+                TO_PRINT="$((TERM_COLS - 5))"
+                { [[ ${#input1} -gt ${TO_PRINT} ]] && out="[ ${input1:0:TO_PRINT}..]"; } || { out="[ ${input1} ]"; }
             else
                 declare input1="${2}" input2="${3}" symbol="${4}" TO_PRINT temp out
                 TO_PRINT="$((TERM_COLS * 40 / 100))"
@@ -372,6 +367,33 @@ _remove_array_duplicates() {
         Aunique+=("${i}") && Aseen[${i}]=x
     done
     printf '%s\n' "${Aunique[@]}"
+}
+
+###################################################
+# Alternative to timeout command
+# Globals: None
+# Arguments: 1 and rest
+#   ${1} = amount of time to sleep
+#   rest = command to execute
+# Result: Read description
+# Reference:
+#   https://stackoverflow.com/a/11056286
+###################################################
+_timeout() {
+    declare -i sleep="${1}" && shift
+    declare -i pid watcher
+    {
+        { "${@}"; } &
+        pid="${!}"
+        { read -r -t "${sleep:-10}" && kill -HUP "${pid}"; } &
+        watcher="${!}"
+        if wait "${pid}" 2> /dev/null; then
+            kill -9 "${watcher}"
+            return 0
+        else
+            return 1
+        fi
+    } &> /dev/null
 }
 
 ###################################################

--- a/utils.sh
+++ b/utils.sh
@@ -234,7 +234,7 @@ _full_path() {
 
 ###################################################
 # Fetch latest commit sha of release or branch
-# Uses github rest api v3
+# Do not use github rest api because rate limit error occurs
 # Globals: None
 # Arguments: 3
 #   ${1} = "branch" or "release"
@@ -246,13 +246,17 @@ _get_latest_sha() {
     declare LATEST_SHA
     case "${1:-${TYPE}}" in
         branch)
-            LATEST_SHA="$(curl --compressed -s https://api.github.com/repos/"${3:-${REPO}}"/commits/"${2:-${TYPE_VALUE}}" | _json_value sha 1 1)"
+            LATEST_SHA="$(hash="$(curl --compressed -s https://github.com/"${3:-${REPO}}"/commits/"${2:-${TYPE_VALUE}}".atom -r 0-2000 | grep "Commit\\/" -m1)" && {
+                read -r firstline <<< "${hash}" && regex="(/.*<)" && [[ ${firstline} =~ ${regex} ]] && printf "%s\n" "${BASH_REMATCH[1]:1:-1}"
+            })"
             ;;
         release)
-            LATEST_SHA="$(curl --compressed -s https://api.github.com/repos/"${3:-${REPO}}"/releases/"${2:-${TYPE_VALUE}}" | _json_value tag_name 1 1)"
+            LATEST_SHA="$(hash="$(curl -L --compressed -s https://github.com/"${3:-${REPO}}"/releases/"${2:-${TYPE_VALUE}}" | grep "=\"/""${3:-${REPO}}""/commit" -m1)" && {
+                read -r firstline <<< "${hash}" && : "${hash/*commit\//}" && printf "%s\n" "${_/\"*/}"
+            })"
             ;;
     esac
-    printf "%s\n" "${LATEST_SHA}"
+    printf "%b" "${LATEST_SHA:+${LATEST_SHA}\n}"
 }
 
 ###################################################


### PR DESCRIPTION
* Improve some functions

    _json_value, _full_path, _print_center, _check_internet

* Add skip internet check flag to install.sh.

* Show more detailed info when updating/installing.

* Add a check in sync script to check if target folder is empty.

* Skip internet check when self updating.

* Use jobs -p to check background xargs proccess, in case of parallel uploads.

* Setup tempfile only when parallel uploads are enabled.