### PR TITLE
Update README | create upload-utils | Improvements to cleanup and auto update

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
   - [Updation](#updation)
 - [Usage](#usage)
   - [Generating Oauth Credentials](#generating-oauth-credentials)
+  - [Enable Drive API](#enable-drive-api)
   - [First Run](#first-run)
   - [Config file](#config)
   - [Upload](#upload)
@@ -295,20 +296,40 @@ There are two methods:
 
 ## Usage
 
-First, we need to obtain our Oauth credentials, here's how to do it:
+First, we need to obtain our oauth credentials, here's how to do it:
 
 ### Generating Oauth Credentials
 
-- Log into google developer console at [google console](https://console.developers.google.com/).
-- Create new Project or use existing project.
-- Creating new OAuth 2.0 Credentials:
-  - Select Application type "other".
-  - Provide name for the new credentials. ( anything )
-  - This would provide a new Client ID and Client Secret.
-  - Download your credentials.json by clicking on the download button.
-- Enable Google Drive API for the project under "Library".
+- Follow [Enable Drive API](#enable-drive-api) section.
+- Open [google console](https://console.developers.google.com/).
+- Click on "Credentials".
+- Click "Create credentials" and select oauth client id.
+- Select Application type "Desktop app" or "other".
+- Provide name for the new credentials. ( anything )
+- This would provide a new Client ID and Client Secret.
+- Download your credentials.json by clicking on the download button.
 
-Now, we have obtained our credentials, move to next section to use those credentials to setup:
+Now, we have obtained our credentials, move to the [First run](#first-run) section to use those credentials:
+
+### Enable Drive API
+
+- Log into google developer console at [google console](https://console.developers.google.com/).
+- Click select project at the right side of "Google Cloud Platform" of upper left of window.
+
+If you cannot see the project, please try to access to [https://console.cloud.google.com/cloud-resource-manager](https://console.cloud.google.com/cloud-resource-manager).
+
+You can also create new project at there. When you create a new project there, please click the left of "Google Cloud Platform". You can see it like 3 horizontal lines.
+
+By this, a side bar is opened. At there, select "API & Services" -> "Library". After this, follow the below steps:
+
+- Click "NEW PROJECT" and input the "Project Name".
+- Click "CREATE" and open the created project.
+- Click "Enable APIs and get credentials like keys".
+- Go to "Library"
+- Input "Drive API" in "Search for APIs & Services".
+- Click "Google Drive API" and click "ENABLE".
+
+[Go back to oauth credentials setup](#generating-oauth-credentials)
 
 ### First Run
 

--- a/bash/common-utils.bash
+++ b/bash/common-utils.bash
@@ -161,24 +161,6 @@ _display_time() {
 }
 
 ###################################################
-# Extract ID from a googledrive folder/file url.
-# Globals: None
-# Arguments: 1
-#   ${1} = googledrive folder/file url.
-# Result: print extracted ID
-###################################################
-_extract_id() {
-    [[ $# = 0 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
-    declare LC_ALL=C ID="${1}"
-    case "${ID}" in
-        *'drive.google.com'*'id='*) ID="${ID##*id=}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
-        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) ID="${ID##*\/d\/}" && ID="${ID%%\/*}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
-        *'drive.google.com'*'drive'*'folders'*) ID="${ID##*\/folders\/}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
-    esac
-    printf "%b" "${ID:+${ID}\n}"
-}
-
-###################################################
 # Fetch latest commit sha of release or branch
 # Do not use github rest api because rate limit error occurs
 # Globals: None

--- a/bash/common-utils.bash
+++ b/bash/common-utils.bash
@@ -366,6 +366,6 @@ _url_encode() {
                 printf '%%%02X' "'${_}"
                 ;;
         esac
-    done
+    done 2>| /dev/null
     printf '\n'
 }

--- a/bash/release/gsync
+++ b/bash/release/gsync
@@ -162,24 +162,6 @@ _display_time() {
 }
 
 ###################################################
-# Extract ID from a googledrive folder/file url.
-# Globals: None
-# Arguments: 1
-#   ${1} = googledrive folder/file url.
-# Result: print extracted ID
-###################################################
-_extract_id() {
-    [[ $# = 0 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
-    declare LC_ALL=C ID="${1}"
-    case "${ID}" in
-        *'drive.google.com'*'id='*) ID="${ID##*id=}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
-        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) ID="${ID##*\/d\/}" && ID="${ID%%\/*}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
-        *'drive.google.com'*'drive'*'folders'*) ID="${ID##*\/folders\/}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
-    esac
-    printf "%b" "${ID:+${ID}\n}"
-}
-
-###################################################
 # Fetch latest commit sha of release or branch
 # Do not use github rest api because rate limit error occurs
 # Globals: None

--- a/bash/release/gsync
+++ b/bash/release/gsync
@@ -367,7 +367,7 @@ _url_encode() {
                 printf '%%%02X' "'${_}"
                 ;;
         esac
-    done
+    done 2>| /dev/null
     printf '\n'
 }
 # Sync a FOLDER to google drive forever using labbots/google-drive-upload

--- a/bash/release/gupload
+++ b/bash/release/gupload
@@ -1062,6 +1062,35 @@ _version_info() {
 }
 
 ###################################################
+# Function to cleanup config file
+# Remove invalid access tokens on the basis of corresponding expiry
+# Globals: None
+# Arguments: 1
+#   ${1} = config file
+# Result: read description
+###################################################
+_cleanup_config() {
+    declare config="${1:?Error: Missing config}" values_regex
+
+    ! [ -f "${config}" ] && return 0
+
+    while read -r line; do
+        expiry_value_name="${line%%=*}"
+        token_value_name="${expiry_value_name%%_EXPIRY}"
+
+        : "${line##*=}" && : "${_%\"}" && expiry="${_#\"}"
+        [[ ${expiry} -le "$(printf "%(%s)T\\n" "-1")" ]] &&
+            values_regex="${values_regex:+${values_regex}|}${expiry_value_name}=\".*\"|${token_value_name}=\".*\""
+
+    done <<< "$(grep -F ACCESS_TOKEN_EXPIRY "${config}" || :)"
+
+    chmod +w "${config}" &&
+        printf "%s\n" "$(grep -Ev "^\$${values_regex:+|${values_regex}}" "${config}")" >| "${config}" &&
+        chmod -w "${config}"
+    return 0
+}
+
+###################################################
 # Process all arguments given to the script
 # Globals: 2 variable, 1 function
 #   Variable - HOME, CONFIG
@@ -1672,7 +1701,7 @@ main() {
                 printf "\n\n%s\n" "Script exited manually."
                 kill -- -$$ &
             else
-                _auto_update &
+                { _cleanup_config "${CONFIG}" && _auto_update; } &
             fi
         } 2>| /dev/null 1>&2 || :
         return 0

--- a/bash/release/gupload
+++ b/bash/release/gupload
@@ -162,24 +162,6 @@ _display_time() {
 }
 
 ###################################################
-# Extract ID from a googledrive folder/file url.
-# Globals: None
-# Arguments: 1
-#   ${1} = googledrive folder/file url.
-# Result: print extracted ID
-###################################################
-_extract_id() {
-    [[ $# = 0 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
-    declare LC_ALL=C ID="${1}"
-    case "${ID}" in
-        *'drive.google.com'*'id='*) ID="${ID##*id=}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
-        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) ID="${ID##*\/d\/}" && ID="${ID%%\/*}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
-        *'drive.google.com'*'drive'*'folders'*) ID="${ID##*\/folders\/}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
-    esac
-    printf "%b" "${ID:+${ID}\n}"
-}
-
-###################################################
 # Fetch latest commit sha of release or branch
 # Do not use github rest api because rate limit error occurs
 # Globals: None
@@ -370,128 +352,6 @@ _url_encode() {
     done 2>| /dev/null
     printf '\n'
 }
-# shellcheck source=/dev/null
-
-###################################################
-# A simple wrapper to check tempfile for access token and make authorized oauth requests to drive api
-###################################################
-_api_request() {
-    . "${TMPFILE}_ACCESS_TOKEN"
-
-    curl --compressed \
-        -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-        "${@}"
-}
-
-###################################################
-# Method to regenerate access_token ( also updates in config ).
-# Make a request on https://www.googleapis.com/oauth2/""${API_VERSION}""/tokeninfo?access_token=${ACCESS_TOKEN} url and check if the given token is valid, if not generate one.
-# Globals: 9 variables, 2 functions
-#   Variables - CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, TOKEN_URL, CONFIG, API_URL, API_VERSION, QUIET, NO_UPDATE_TOKEN
-#   Functions - _update_config and _print_center
-# Result: Update access_token and expiry else print error
-###################################################
-_get_access_token_and_update() {
-    RESPONSE="${1:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
-    if ACCESS_TOKEN="$(_json_value access_token 1 1 <<< "${RESPONSE}")"; then
-        ACCESS_TOKEN_EXPIRY="$(($(printf "%(%s)T\\n" "-1") + $(_json_value expires_in 1 1 <<< "${RESPONSE}") - 1))"
-        _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-        _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
-    else
-        "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." 1>&2
-        printf "%s\n" "${RESPONSE}" 1>&2
-        return 1
-    fi
-    return 0
-}
-
-###################################################
-# A small function to get rootdir id for files in sub folder uploads
-# Globals: 1 variable, 1 function
-#   Variables - DIRIDS
-#   Functions - _dirname
-# Arguments: 1
-#   ${1} = filename
-# Result: read discription
-###################################################
-_get_rootdir_id() {
-    declare file="${1:?Error: give filename}" __rootdir __temp
-    __rootdir="$(_dirname "${file}")"
-    __temp="$(grep -F "|:_//_:|${__rootdir}|:_//_:|" <<< "${DIRIDS:?Error: DIRIDS Missing}" || :)"
-    printf "%s\n" "${__temp%%"|:_//_:|${__rootdir}|:_//_:|"}"
-    return 0
-}
-
-###################################################
-# Used in collecting file properties from output json after a file has been uploaded/cloned
-# Also handles logging in log file if LOG_FILE_ID is set
-# Globals: 1 variables, 2 functions
-#   Variables - LOG_FILE_ID
-#   Functions - _error_logging_upload, _json_value
-# Arguments: 1
-#   ${1} = output jsom
-# Result: set fileid and link, save info to log file if required
-###################################################
-_collect_file_info() {
-    declare json="${1}" info
-    FILE_ID="$(_json_value id 1 1 <<< "${json}")" || { _error_logging_upload "${2}" "${json}"; }
-    [[ -z ${LOG_FILE_ID} || -d ${LOG_FILE_ID} ]] && return 0
-    info="$(
-        printf "%s\n" "Link: https://drive.google.com/open?id=${FILE_ID}"
-        printf "%s\n" "Name: $(_json_value name 1 1 <<< "${json}" || :)"
-        printf "%s\n" "ID: ${FILE_ID}"
-        printf "%s\n" "Type: $(_json_value mimeType 1 1 <<< "${json}" || :)"
-    )"
-    printf "%s\n\n" "${info}" >> "${LOG_FILE_ID}"
-    return 0
-}
-
-###################################################
-# Error logging wrapper
-###################################################
-_error_logging_upload() {
-    declare log="${2}"
-    "${QUIET:-_print_center}" "justify" "Upload ERROR" ", ${1:-} not ${STRING:-uploaded}." "=" 1>&2
-    case "${log}" in
-        # https://github.com/rclone/rclone/issues/3857#issuecomment-573413789
-        *'"message": "User rate limit exceeded."'*)
-            printf "%s\n\n%s\n" "${log}" \
-                "Today's upload limit reached for this account. Use another account to upload or wait for tomorrow." 1>&2
-            # Never retry if upload limit reached
-            export RETRY=0
-            ;;
-        '' | *) printf "%s\n" "${log}" 1>&2 ;;
-    esac
-    printf "\n\n\n" 1>&2
-    return 1
-}
-
-###################################################
-# Get information for a gdrive folder/file.
-# Globals: 3 variables, 1 function
-#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
-#   Functions - _json_value
-# Arguments: 2
-#   ${1} = folder/file gdrive id
-#   ${2} = information to fetch, e.g name, id
-# Result: On
-#   Success - print fetched value
-#   Error   - print "message" field from the json
-# Reference:
-#   https://developers.google.com/drive/api/v3/search-files
-###################################################
-_drive_info() {
-    [[ $# -lt 2 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
-    declare folder_id="${1}" fetch="${2}" search_response
-
-    "${EXTRA_LOG}" "justify" "Fetching info.." "-" 1>&2
-    search_response="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-        "${API_URL}/drive/${API_VERSION}/files/${folder_id}?fields=${fetch}&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
-    _clear_line 1 1>&2
-
-    printf "%b" "${search_response:+${search_response}\n}"
-    return 0
-}
 
 ###################################################
 # Search for an existing file on gdrive with write permission.
@@ -517,6 +377,73 @@ _check_existing_file() {
     _clear_line 1 1>&2
 
     { _json_value id 1 1 <<< "${search_response}" 2>| /dev/null 1>&2 && printf "%s\n" "${search_response}"; } || return 1
+    return 0
+}
+
+###################################################
+# Copy/Clone a public gdrive file/folder from another/same gdrive account
+# Globals: 6 variables, 2 functions
+#   Variables - API_URL, API_VERSION, CURL_PROGRESS, LOG_FILE_ID, QUIET, ACCESS_TOKEN
+#   Functions - _print_center, _check_existing_file, _json_value, _bytes_to_human, _clear_line
+# Arguments: 5
+#   ${1} = update or upload ( upload type )
+#   ${2} = file id to upload
+#   ${3} = root dir id for file
+#   ${4} = name of file
+#   ${5} = size of file
+# Result: On
+#   Success - Upload/Update file and export FILE_ID
+#   Error - return 1
+# Reference:
+#   https://developers.google.com/drive/api/v2/reference/files/copy
+###################################################
+_clone_file() {
+    [[ $# -lt 5 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
+    declare job="${1}" file_id="${2}" file_root_id="${3}" name="${4}" size="${5}"
+    declare clone_file_post_data clone_file_response readable_size _file_id && STRING="Cloned"
+    clone_file_post_data="{\"parents\": [\"${file_root_id}\"]}"
+    readable_size="$(_bytes_to_human "${size}")"
+
+    _print_center "justify" "${name} " "| ${readable_size}" "="
+
+    if [[ ${job} = update ]]; then
+        declare file_check_json
+        # Check if file actually exists.
+        if file_check_json="$(_check_existing_file "${name}" "${file_root_id}")"; then
+            if [[ -n ${SKIP_DUPLICATES} ]]; then
+                _collect_file_info "${file_check_json}" || return 1
+                _clear_line 1
+                "${QUIET:-_print_center}" "justify" "${name}" " already exists." "=" && return 0
+            else
+                _print_center "justify" "Overwriting file.." "-"
+                { _file_id="$(_json_value id 1 1 <<< "${file_check_json}")" &&
+                    clone_file_post_data="$(_drive_info "${_file_id}" "parents,writersCanShare")"; } ||
+                    { _error_logging_upload "${name}" "${post_data:-${file_check_json}}"; }
+                if [[ ${_file_id} != "${file_id}" ]]; then
+                    _api_request -s \
+                        -X DELETE \
+                        "${API_URL}/drive/${API_VERSION}/files/${_file_id}?supportsAllDrives=true&includeItemsFromAllDrives=true" 2>| /dev/null 1>&2 || :
+                    STRING="Updated"
+                else
+                    _collect_file_info "${file_check_json}" || return 1
+                fi
+            fi
+        else
+            "${EXTRA_LOG}" "justify" "Cloning file.." "-"
+        fi
+    else
+        "${EXTRA_LOG}" "justify" "Cloning file.." "-"
+    fi
+
+    # shellcheck disable=SC2086 # Because unnecessary to another check because ${CURL_PROGRESS} won't be anything problematic.
+    clone_file_response="$(_api_request ${CURL_PROGRESS} \
+        -X POST \
+        -H "Content-Type: application/json; charset=UTF-8" \
+        -d "${clone_file_post_data}" \
+        "${API_URL}/drive/${API_VERSION}/files/${file_id}/copy?supportsAllDrives=true&includeItemsFromAllDrives=true" || :)"
+    for _ in 1 2 3; do _clear_line 1; done
+    _collect_file_info "${clone_file_response}" || return 1
+    "${QUIET:-_print_center}" "justify" "${name} " "| ${readable_size} | ${STRING}" "="
     return 0
 }
 
@@ -559,77 +486,71 @@ _create_directory() {
 }
 
 ###################################################
-# Sub functions for _upload_file function - Start
-# generate resumable upload link
-_generate_upload_link() {
-    "${EXTRA_LOG}" "justify" "Generating upload link.." "-" 1>&2
-    uploadlink="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-        -X "${request_method}" \
-        -H "Content-Type: application/json; charset=UTF-8" \
-        -H "X-Upload-Content-Type: ${mime_type}" \
-        -H "X-Upload-Content-Length: ${inputsize}" \
-        -d "$postdata" \
-        "${url}" \
-        -D - || :)" && _clear_line 1 1>&2
+# Get information for a gdrive folder/file.
+# Globals: 3 variables, 1 function
+#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
+#   Functions - _json_value
+# Arguments: 2
+#   ${1} = folder/file gdrive id
+#   ${2} = information to fetch, e.g name, id
+# Result: On
+#   Success - print fetched value
+#   Error   - print "message" field from the json
+# Reference:
+#   https://developers.google.com/drive/api/v3/search-files
+###################################################
+_drive_info() {
+    [[ $# -lt 2 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
+    declare folder_id="${1}" fetch="${2}" search_response
+
+    "${EXTRA_LOG}" "justify" "Fetching info.." "-" 1>&2
+    search_response="$(_api_request "${CURL_PROGRESS_EXTRA}" \
+        "${API_URL}/drive/${API_VERSION}/files/${folder_id}?fields=${fetch}&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
     _clear_line 1 1>&2
 
-    case "${uploadlink}" in
-        *'ocation: '*'upload_id'*) uploadlink="$(read -r firstline <<< "${uploadlink/*[L,l]ocation: /}" && printf "%s\n" "${firstline//$'\r'/}")" && return 0 ;;
-        '' | *) return 1 ;;
-    esac
-
+    printf "%b" "${search_response:+${search_response}\n}"
     return 0
 }
 
-# Curl command to push the file to google drive.
-_upload_file_from_uri() {
-    _print_center "justify" "Uploading.." "-"
-    # shellcheck disable=SC2086 # Because unnecessary to another check because ${CURL_PROGRESS} won't be anything problematic.
-    upload_body="$(_api_request ${CURL_PROGRESS} \
-        -X PUT \
-        -H "Content-Type: ${mime_type}" \
-        -H "Content-Length: ${content_length}" \
-        -H "Slug: ${slug}" \
-        -T "${input}" \
-        -o- \
-        --url "${uploadlink}" \
-        --globoff \
-        ${CURL_SPEED} ${resume_args1} ${resume_args2} \
-        -H "${resume_args3}" || :)"
-    [[ -z ${VERBOSE_PROGRESS} ]] && for _ in 1 2; do _clear_line 1; done && "${1:-:}"
-    return 0
-}
-# logging in case of successful upload
-_normal_logging_upload() {
-    [[ -z ${VERBOSE_PROGRESS} ]] && _clear_line 1
-    "${QUIET:-_print_center}" "justify" "${slug} " "| ${readable_size} | ${STRING}" "="
-    return 0
-}
-
-# Tempfile Used for resuming interrupted uploads
-_log_upload_session() {
-    [[ ${inputsize} -gt 1000000 ]] && printf "%s\n" "${uploadlink}" >| "${__file}"
-    return 0
-}
-
-# remove upload session
-_remove_upload_session() {
-    rm -f "${__file}"
-    return 0
-}
-
-# wrapper to fully upload a file from scratch
-_full_upload() {
-    _generate_upload_link || { _error_logging_upload "${slug}" "${uploadlink}"; }
-    _log_upload_session
-    _upload_file_from_uri
-    _collect_file_info "${upload_body}" "${slug}" || return 1
-    _normal_logging_upload
-    _remove_upload_session
-    return 0
-}
-# Sub functions for _upload_file function - End
 ###################################################
+# Extract ID from a googledrive folder/file url.
+# Globals: None
+# Arguments: 1
+#   ${1} = googledrive folder/file url.
+# Result: print extracted ID
+###################################################
+_extract_id() {
+    [[ $# = 0 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
+    declare LC_ALL=C ID="${1}"
+    case "${ID}" in
+        *'drive.google.com'*'id='*) ID="${ID##*id=}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
+        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) ID="${ID##*\/d\/}" && ID="${ID%%\/*}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
+        *'drive.google.com'*'drive'*'folders'*) ID="${ID##*\/folders\/}" && ID="${ID%%\?*}" && ID="${ID%%\&*}" ;;
+    esac
+    printf "%b" "${ID:+${ID}\n}"
+}
+
+###################################################
+# Method to regenerate access_token ( also updates in config ).
+# Make a request on https://www.googleapis.com/oauth2/""${API_VERSION}""/tokeninfo?access_token=${ACCESS_TOKEN} url and check if the given token is valid, if not generate one.
+# Globals: 9 variables, 2 functions
+#   Variables - CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, TOKEN_URL, CONFIG, API_URL, API_VERSION, QUIET, NO_UPDATE_TOKEN
+#   Functions - _update_config and _print_center
+# Result: Update access_token and expiry else print error
+###################################################
+_get_access_token_and_update() {
+    RESPONSE="${1:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
+    if ACCESS_TOKEN="$(_json_value access_token 1 1 <<< "${RESPONSE}")"; then
+        ACCESS_TOKEN_EXPIRY="$(($(printf "%(%s)T\\n" "-1") + $(_json_value expires_in 1 1 <<< "${RESPONSE}") - 1))"
+        _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
+        _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+    else
+        "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
+        printf "%s\n" "${RESPONSE}" 1>&2
+        return 1
+    fi
+    return 0
+}
 
 ###################################################
 # Upload ( Create/Update ) files on gdrive.
@@ -746,6 +667,182 @@ _upload_file() {
 }
 
 ###################################################
+# Sub functions for _upload_file function - Start
+# generate resumable upload link
+_generate_upload_link() {
+    "${EXTRA_LOG}" "justify" "Generating upload link.." "-" 1>&2
+    uploadlink="$(_api_request "${CURL_PROGRESS_EXTRA}" \
+        -X "${request_method}" \
+        -H "Content-Type: application/json; charset=UTF-8" \
+        -H "X-Upload-Content-Type: ${mime_type}" \
+        -H "X-Upload-Content-Length: ${inputsize}" \
+        -d "$postdata" \
+        "${url}" \
+        -D - || :)" && _clear_line 1 1>&2
+    _clear_line 1 1>&2
+
+    case "${uploadlink}" in
+        *'ocation: '*'upload_id'*) uploadlink="$(read -r firstline <<< "${uploadlink/*[L,l]ocation: /}" && printf "%s\n" "${firstline//$'\r'/}")" && return 0 ;;
+        '' | *) return 1 ;;
+    esac
+
+    return 0
+}
+
+# Curl command to push the file to google drive.
+_upload_file_from_uri() {
+    _print_center "justify" "Uploading.." "-"
+    # shellcheck disable=SC2086 # Because unnecessary to another check because ${CURL_PROGRESS} won't be anything problematic.
+    upload_body="$(_api_request ${CURL_PROGRESS} \
+        -X PUT \
+        -H "Content-Type: ${mime_type}" \
+        -H "Content-Length: ${content_length}" \
+        -H "Slug: ${slug}" \
+        -T "${input}" \
+        -o- \
+        --url "${uploadlink}" \
+        --globoff \
+        ${CURL_SPEED} ${resume_args1} ${resume_args2} \
+        -H "${resume_args3}" || :)"
+    [[ -z ${VERBOSE_PROGRESS} ]] && for _ in 1 2; do _clear_line 1; done && "${1:-:}"
+    return 0
+}
+
+# logging in case of successful upload
+_normal_logging_upload() {
+    [[ -z ${VERBOSE_PROGRESS} ]] && _clear_line 1
+    "${QUIET:-_print_center}" "justify" "${slug} " "| ${readable_size} | ${STRING}" "="
+    return 0
+}
+
+# Tempfile Used for resuming interrupted uploads
+_log_upload_session() {
+    [[ ${inputsize} -gt 1000000 ]] && printf "%s\n" "${uploadlink}" >| "${__file}"
+    return 0
+}
+
+# remove upload session
+_remove_upload_session() {
+    rm -f "${__file}"
+    return 0
+}
+
+# wrapper to fully upload a file from scratch
+_full_upload() {
+    _generate_upload_link || { _error_logging_upload "${slug}" "${uploadlink}"; }
+    _log_upload_session
+    _upload_file_from_uri
+    _collect_file_info "${upload_body}" "${slug}" || return 1
+    _normal_logging_upload
+    _remove_upload_session
+    return 0
+}
+# Sub functions for _upload_file function - End
+###################################################
+
+###################################################
+# Share a gdrive file/folder
+# Globals: 3 variables, 4 functions
+#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
+#   Functions - _url_encode, _json_value, _print_center, _clear_line
+# Arguments: 2
+#   ${1} = gdrive ID of folder/file
+#   ${2} = Email to which file will be shared ( optional )
+# Result: read description
+# Reference:
+#   https://developers.google.com/drive/api/v3/manage-sharing
+###################################################
+_share_id() {
+    [[ $# -lt 2 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
+    declare id="${1}" share_email="${2}" role="reader" type="${share_email:+user}"
+    declare type share_post_data share_post_data share_response
+
+    "${EXTRA_LOG}" "justify" "Sharing.." "-" 1>&2
+    share_post_data="{\"role\":\"${role}\",\"type\":\"${type:-anyone}\"${share_email:+,\\\"emailAddress\\\":\\\"${share_email}\\\"}}"
+
+    share_response="$(_api_request "${CURL_PROGRESS_EXTRA}" \
+        -X POST \
+        -H "Content-Type: application/json; charset=UTF-8" \
+        -d "${share_post_data}" \
+        "${API_URL}/drive/${API_VERSION}/files/${id}/permissions?supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
+    _clear_line 1 1>&2
+
+    { _json_value id 1 1 <<< "${share_response}" 2>| /dev/null 1>&2 && return 0; } ||
+        { printf "%s\n" "Error: Cannot Share." 1>&2 && printf "%s\n" "${share_response}" 1>&2 && return 1; }
+}
+# shellcheck source=/dev/null
+
+###################################################
+# A simple wrapper to check tempfile for access token and make authorized oauth requests to drive api
+###################################################
+_api_request() {
+    . "${TMPFILE}_ACCESS_TOKEN"
+
+    curl --compressed \
+        -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+        "${@}"
+}
+
+###################################################
+# Used in collecting file properties from output json after a file has been uploaded/cloned
+# Also handles logging in log file if LOG_FILE_ID is set
+# Globals: 1 variables, 2 functions
+#   Variables - LOG_FILE_ID
+#   Functions - _error_logging_upload, _json_value
+# Arguments: 1
+#   ${1} = output jsom
+# Result: set fileid and link, save info to log file if required
+###################################################
+_collect_file_info() {
+    declare json="${1}" info
+    FILE_ID="$(_json_value id 1 1 <<< "${json}")" || { _error_logging_upload "${2}" "${json}"; }
+    [[ -z ${LOG_FILE_ID} || -d ${LOG_FILE_ID} ]] && return 0
+    info="Link: https://drive.google.com/open?id=${FILE_ID}
+Name: $(_json_value name 1 1 <<< "${json}" || :)
+ID: ${FILE_ID}
+Type: $(_json_value mimeType 1 1 <<< "${json}" || :)"
+    printf "%s\n\n" "${info}" >> "${LOG_FILE_ID}"
+    return 0
+}
+
+###################################################
+# Error logging wrapper
+###################################################
+_error_logging_upload() {
+    declare log="${2}"
+    "${QUIET:-_print_center}" "justify" "Upload ERROR" ", ${1:-} not ${STRING:-uploaded}." "=" 1>&2
+    case "${log}" in
+        # https://github.com/rclone/rclone/issues/3857#issuecomment-573413789
+        *'"message": "User rate limit exceeded."'*)
+            printf "%s\n\n%s\n" "${log}" \
+                "Today's upload limit reached for this account. Use another account to upload or wait for tomorrow." 1>&2
+            # Never retry if upload limit reached
+            export RETRY=0
+            ;;
+        '' | *) printf "%s\n" "${log}" 1>&2 ;;
+    esac
+    printf "\n\n\n" 1>&2
+    return 1
+}
+
+###################################################
+# A small function to get rootdir id for files in sub folder uploads
+# Globals: 1 variable, 1 function
+#   Variables - DIRIDS
+#   Functions - _dirname
+# Arguments: 1
+#   ${1} = filename
+# Result: read discription
+###################################################
+_get_rootdir_id() {
+    declare file="${1:?Error: give filename}" __rootdir __temp
+    __rootdir="$(_dirname "${file}")"
+    __temp="$(grep -F "|:_//_:|${__rootdir}|:_//_:|" <<< "${DIRIDS:?Error: DIRIDS Missing}" || :)"
+    printf "%s\n" "${__temp%%"|:_//_:|${__rootdir}|:_//_:|"}"
+    return 0
+}
+
+###################################################
 # A extra wrapper for _upload_file function to properly handle retries
 # also handle uploads in case uploading from folder
 # Globals: 2 variables, 1 function
@@ -834,104 +931,6 @@ _upload_folder() {
             ;;
     esac
     return 0
-}
-
-###################################################
-# Copy/Clone a public gdrive file/folder from another/same gdrive account
-# Globals: 6 variables, 2 functions
-#   Variables - API_URL, API_VERSION, CURL_PROGRESS, LOG_FILE_ID, QUIET, ACCESS_TOKEN
-#   Functions - _print_center, _check_existing_file, _json_value, _bytes_to_human, _clear_line
-# Arguments: 5
-#   ${1} = update or upload ( upload type )
-#   ${2} = file id to upload
-#   ${3} = root dir id for file
-#   ${4} = name of file
-#   ${5} = size of file
-# Result: On
-#   Success - Upload/Update file and export FILE_ID
-#   Error - return 1
-# Reference:
-#   https://developers.google.com/drive/api/v2/reference/files/copy
-###################################################
-_clone_file() {
-    [[ $# -lt 5 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
-    declare job="${1}" file_id="${2}" file_root_id="${3}" name="${4}" size="${5}"
-    declare clone_file_post_data clone_file_response readable_size _file_id && STRING="Cloned"
-    clone_file_post_data="{\"parents\": [\"${file_root_id}\"]}"
-    readable_size="$(_bytes_to_human "${size}")"
-
-    _print_center "justify" "${name} " "| ${readable_size}" "="
-
-    if [[ ${job} = update ]]; then
-        declare file_check_json
-        # Check if file actually exists.
-        if file_check_json="$(_check_existing_file "${name}" "${file_root_id}")"; then
-            if [[ -n ${SKIP_DUPLICATES} ]]; then
-                _collect_file_info "${file_check_json}" || return 1
-                _clear_line 1
-                "${QUIET:-_print_center}" "justify" "${name}" " already exists." "=" && return 0
-            else
-                _print_center "justify" "Overwriting file.." "-"
-                { _file_id="$(_json_value id 1 1 <<< "${file_check_json}")" &&
-                    clone_file_post_data="$(_drive_info "${_file_id}" "parents,writersCanShare")"; } ||
-                    { _error_logging_upload "${name}" "${post_data:-${file_check_json}}"; }
-                if [[ ${_file_id} != "${file_id}" ]]; then
-                    _api_request -s \
-                        -X DELETE \
-                        "${API_URL}/drive/${API_VERSION}/files/${_file_id}?supportsAllDrives=true&includeItemsFromAllDrives=true" 2>| /dev/null 1>&2 || :
-                    STRING="Updated"
-                else
-                    _collect_file_info "${file_check_json}" || return 1
-                fi
-            fi
-        else
-            "${EXTRA_LOG}" "justify" "Cloning file.." "-"
-        fi
-    else
-        "${EXTRA_LOG}" "justify" "Cloning file.." "-"
-    fi
-
-    # shellcheck disable=SC2086 # Because unnecessary to another check because ${CURL_PROGRESS} won't be anything problematic.
-    clone_file_response="$(_api_request ${CURL_PROGRESS} \
-        -X POST \
-        -H "Content-Type: application/json; charset=UTF-8" \
-        -d "${clone_file_post_data}" \
-        "${API_URL}/drive/${API_VERSION}/files/${file_id}/copy?supportsAllDrives=true&includeItemsFromAllDrives=true" || :)"
-    for _ in 1 2 3; do _clear_line 1; done
-    _collect_file_info "${clone_file_response}" || return 1
-    "${QUIET:-_print_center}" "justify" "${name} " "| ${readable_size} | ${STRING}" "="
-    return 0
-}
-
-###################################################
-# Share a gdrive file/folder
-# Globals: 3 variables, 4 functions
-#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
-#   Functions - _url_encode, _json_value, _print_center, _clear_line
-# Arguments: 2
-#   ${1} = gdrive ID of folder/file
-#   ${2} = Email to which file will be shared ( optional )
-# Result: read description
-# Reference:
-#   https://developers.google.com/drive/api/v3/manage-sharing
-###################################################
-_share_id() {
-    [[ $# -lt 2 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
-    declare id="${1}" share_email="${2}" role="reader" type="${share_email:+user}"
-    declare type share_post_data share_post_data share_response
-
-    "${EXTRA_LOG}" "justify" "Sharing.." "-" 1>&2
-    share_post_data="{\"role\":\"${role}\",\"type\":\"${type:-anyone}\"${share_email:+,\\\"emailAddress\\\":\\\"${share_email}\\\"}}"
-
-    share_response="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-        -X POST \
-        -H "Content-Type: application/json; charset=UTF-8" \
-        -d "${share_post_data}" \
-        "${API_URL}/drive/${API_VERSION}/files/${id}/permissions?supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
-    _clear_line 1 1>&2
-
-    { _json_value id 1 1 <<< "${share_response}" 2>| /dev/null 1>&2 && return 0; } ||
-        { printf "%s\n" "Error: Cannot Share." 1>&2 && printf "%s\n" "${share_response}" 1>&2 && return 1; }
 }
 # Upload a file to Google Drive
 # shellcheck source=/dev/null
@@ -1630,7 +1629,8 @@ main() {
 
     [[ -z ${SELF_SOURCE} ]] && {
         UTILS_FOLDER="${UTILS_FOLDER:-${PWD}}"
-        { . "${UTILS_FOLDER}"/common-utils.bash && . "${UTILS_FOLDER}"/drive-utils.bash; } || { printf "Error: Unable to source util files.\n" && exit 1; }
+        { . "${UTILS_FOLDER}"/common-utils.bash && . "${UTILS_FOLDER}"/drive-utils.bash && . "${UTILS_FOLDER}"/upload-utils.bash; } ||
+            { printf "Error: Unable to source util files.\n" && exit 1; }
     }
 
     _check_bash_version && set -o errexit -o noclobber -o pipefail

--- a/bash/release/gupload
+++ b/bash/release/gupload
@@ -367,7 +367,7 @@ _url_encode() {
                 printf '%%%02X' "'${_}"
                 ;;
         esac
-    done
+    done 2>| /dev/null
     printf '\n'
 }
 # shellcheck source=/dev/null

--- a/bash/release/gupload
+++ b/bash/release/gupload
@@ -988,15 +988,12 @@ _short_help() {
 ###################################################
 _auto_update() {
     export REPO
-    (
-        _REPO="${REPO}"
-        command -v "${COMMAND_NAME}" 1> /dev/null &&
-            if [[ -n "${_REPO:+${COMMAND_NAME:+${INSTALL_PATH:+${TYPE:+${TYPE_VALUE}}}}}" ]]; then
-                current_time="$(printf "%(%s)T\\n" "-1")"
-                [[ $((LAST_UPDATE_TIME + AUTO_UPDATE_INTERVAL)) -lt ${current_time} ]] && _update
-                _update_value LAST_UPDATE_TIME "${current_time}"
-            fi
-    ) 2>| /dev/null 1>&2 &
+    command -v "${COMMAND_NAME}" 1> /dev/null &&
+        if [[ -n "${REPO:+${COMMAND_NAME:+${INSTALL_PATH:+${TYPE:+${TYPE_VALUE}}}}}" ]]; then
+            current_time="$(printf "%(%s)T\\n" "-1")"
+            [[ $((LAST_UPDATE_TIME + AUTO_UPDATE_INTERVAL)) -lt ${current_time} ]] && _update
+            _update_value LAST_UPDATE_TIME "${current_time}"
+        fi
     return 0
 }
 
@@ -1645,27 +1642,29 @@ main() {
             # unhide the cursor if hidden
             [[ -n ${SUPPORT_ANSI_ESCAPES} ]] && printf "\033[?25h"
 
-            # update the config with latest ACCESS_TOKEN and ACCESS_TOKEN_EXPIRY only if changed
-            NEW_ACCESS_TOKEN="$(. "${TMPFILE}_ACCESS_TOKEN" && printf "%s\n" "${ACCESS_TOKEN}")"
-            [[ ${INITIAL_ACCESS_TOKEN} = "${NEW_ACCESS_TOKEN}" ]] || {
-                _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-                _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+            [[ -f ${TMPFILE}_ACCESS_TOKEN ]] && {
+                # update the config with latest ACCESS_TOKEN and ACCESS_TOKEN_EXPIRY only if changed
+                . "${TMPFILE}_ACCESS_TOKEN"
+                [[ ${INITIAL_ACCESS_TOKEN} = "${ACCESS_TOKEN}" ]] || {
+                    _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
+                    _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                }
             }
 
             # grab all chidren processes of access token service
             # https://askubuntu.com/a/512872
-            token_service_pids="$(ps --ppid="${ACCESS_TOKEN_SERVICE_PID}" -o pid=)"
-            # first kill parent id, then children processes
-            kill "${ACCESS_TOKEN_SERVICE_PID}"
-            for pid in ${token_service_pids}; do
-                kill "${pid}"
-            done
+            [[ -n ${ACCESS_TOKEN_SERVICE_PID} ]] && {
+                token_service_pids="$(ps --ppid="${ACCESS_TOKEN_SERVICE_PID}" -o pid=)"
+                # first kill parent id, then children processes
+                kill "${ACCESS_TOKEN_SERVICE_PID}"
+            }
 
-            # manually kill all script children pids
+            # grab all script children pids
             script_children_pids="$(ps --ppid="${MAIN_PID}" -o pid=)"
-            for pid in ${script_children_pids}; do
-                kill "${pid}"
-            done
+
+            # kill all grabbed children processes
+            # shellcheck disable=SC2086
+            kill ${token_service_pids} ${script_children_pids}
 
             rm -f "${TMPFILE:?}"*
 
@@ -1673,9 +1672,9 @@ main() {
                 printf "\n\n%s\n" "Script exited manually."
                 kill -- -$$ &
             else
-                _auto_update
+                _auto_update &
             fi
-        } 2>| /dev/null || :
+        } 2>| /dev/null 1>&2 || :
         return 0
     }
 

--- a/bash/upload-utils.bash
+++ b/bash/upload-utils.bash
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# shellcheck source=/dev/null
+
+###################################################
+# A simple wrapper to check tempfile for access token and make authorized oauth requests to drive api
+###################################################
+_api_request() {
+    . "${TMPFILE}_ACCESS_TOKEN"
+
+    curl --compressed \
+        -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+        "${@}"
+}
+
+###################################################
+# Used in collecting file properties from output json after a file has been uploaded/cloned
+# Also handles logging in log file if LOG_FILE_ID is set
+# Globals: 1 variables, 2 functions
+#   Variables - LOG_FILE_ID
+#   Functions - _error_logging_upload, _json_value
+# Arguments: 1
+#   ${1} = output jsom
+# Result: set fileid and link, save info to log file if required
+###################################################
+_collect_file_info() {
+    declare json="${1}" info
+    FILE_ID="$(_json_value id 1 1 <<< "${json}")" || { _error_logging_upload "${2}" "${json}"; }
+    [[ -z ${LOG_FILE_ID} || -d ${LOG_FILE_ID} ]] && return 0
+    info="Link: https://drive.google.com/open?id=${FILE_ID}
+Name: $(_json_value name 1 1 <<< "${json}" || :)
+ID: ${FILE_ID}
+Type: $(_json_value mimeType 1 1 <<< "${json}" || :)"
+    printf "%s\n\n" "${info}" >> "${LOG_FILE_ID}"
+    return 0
+}
+
+###################################################
+# Error logging wrapper
+###################################################
+_error_logging_upload() {
+    declare log="${2}"
+    "${QUIET:-_print_center}" "justify" "Upload ERROR" ", ${1:-} not ${STRING:-uploaded}." "=" 1>&2
+    case "${log}" in
+        # https://github.com/rclone/rclone/issues/3857#issuecomment-573413789
+        *'"message": "User rate limit exceeded."'*)
+            printf "%s\n\n%s\n" "${log}" \
+                "Today's upload limit reached for this account. Use another account to upload or wait for tomorrow." 1>&2
+            # Never retry if upload limit reached
+            export RETRY=0
+            ;;
+        '' | *) printf "%s\n" "${log}" 1>&2 ;;
+    esac
+    printf "\n\n\n" 1>&2
+    return 1
+}
+
+###################################################
+# A small function to get rootdir id for files in sub folder uploads
+# Globals: 1 variable, 1 function
+#   Variables - DIRIDS
+#   Functions - _dirname
+# Arguments: 1
+#   ${1} = filename
+# Result: read discription
+###################################################
+_get_rootdir_id() {
+    declare file="${1:?Error: give filename}" __rootdir __temp
+    __rootdir="$(_dirname "${file}")"
+    __temp="$(grep -F "|:_//_:|${__rootdir}|:_//_:|" <<< "${DIRIDS:?Error: DIRIDS Missing}" || :)"
+    printf "%s\n" "${__temp%%"|:_//_:|${__rootdir}|:_//_:|"}"
+    return 0
+}
+
+###################################################
+# A extra wrapper for _upload_file function to properly handle retries
+# also handle uploads in case uploading from folder
+# Globals: 2 variables, 1 function
+#   Variables - RETRY, UPLOAD_MODE
+#   Functions - _upload_file
+# Arguments: 3
+#   ${1} = parse or norparse
+#   ${2} = file path
+#   ${3} = if ${1} != parse; gdrive folder id to upload; fi
+# Result: set SUCCESS var on success
+###################################################
+_upload_file_main() {
+    [[ $# -lt 2 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
+    declare file="${2}" dirid _sleep
+    { [[ ${1} = parse ]] && dirid="$(_get_rootdir_id "${file}")"; } || dirid="${3}"
+
+    retry="${RETRY:-0}" && unset RETURN_STATUS
+    until [[ ${retry} -le 0 ]] && [[ -n ${RETURN_STATUS} ]]; do
+        if [[ -n ${4} ]]; then
+            _upload_file "${UPLOAD_MODE:-create}" "${file}" "${dirid}" 2>| /dev/null 1>&2 && RETURN_STATUS=1 && break
+        else
+            _upload_file "${UPLOAD_MODE:-create}" "${file}" "${dirid}" && RETURN_STATUS=1 && break
+        fi
+        sleep "$((_sleep += 1))" # on every retry, sleep the times of retry it is, e.g for 1st, sleep 1, for 2nd, sleep 2
+        RETURN_STATUS=2 retry="$((retry - 1))" && continue
+    done
+    { [[ ${RETURN_STATUS} = 1 ]] && printf "%b" "${4:+${RETURN_STATUS}\n}"; } || printf "%b" "${4:+${RETURN_STATUS}\n}" 1>&2
+    return 0
+}
+
+###################################################
+# Upload all files in the given folder, parallelly or non-parallely and show progress
+# Globals: 7 variables, 3 functions
+#   Variables - VERBOSE, VERBOSE_PROGRESS, NO_OF_PARALLEL_JOBS, NO_OF_FILES, TMPFILE, UTILS_FOLDER and QUIET
+#   Functions - _clear_line, _newline, _print_center and _upload_file_main
+# Arguments: 4
+#   ${1} = parallel or normal
+#   ${2} = parse or norparse
+#   ${3} = filenames with full path
+#   ${4} = if ${2} != parse; then gdrive folder id to upload; fi
+# Result: read discription, set SUCCESS_STATUS & ERROR_STATUS
+###################################################
+_upload_folder() {
+    [[ $# -lt 3 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
+    declare mode="${1}" files="${3}" && PARSE_MODE="${2}" ID="${4:-}" && export PARSE_MODE ID
+    case "${mode}" in
+        normal)
+            [[ ${PARSE_MODE} = parse ]] && _clear_line 1 && _newline "\n"
+
+            while read -u 4 -r file; do
+                _upload_file_main "${PARSE_MODE}" "${file}" "${ID}"
+                : "$((RETURN_STATUS < 2 ? (SUCCESS_STATUS += 1) : (ERROR_STATUS += 1)))"
+                if [[ -n ${VERBOSE:-${VERBOSE_PROGRESS}} ]]; then
+                    _print_center "justify" "Status: ${SUCCESS_STATUS} Uploaded" " | ${ERROR_STATUS} Failed" "=" && _newline "\n"
+                else
+                    for _ in 1 2; do _clear_line 1; done
+                    _print_center "justify" "Status: ${SUCCESS_STATUS} Uploaded" " | ${ERROR_STATUS} Failed" "="
+                fi
+            done 4<<< "${files}"
+            ;;
+        parallel)
+            NO_OF_PARALLEL_JOBS_FINAL="$((NO_OF_PARALLEL_JOBS > NO_OF_FILES ? NO_OF_FILES : NO_OF_PARALLEL_JOBS))"
+            [[ -f "${TMPFILE}"SUCCESS ]] && rm "${TMPFILE}"SUCCESS
+            [[ -f "${TMPFILE}"ERROR ]] && rm "${TMPFILE}"ERROR
+
+            # shellcheck disable=SC2016
+            printf "%s\n" "${files}" | xargs -n1 -P"${NO_OF_PARALLEL_JOBS_FINAL}" -I {} bash -c '
+            _upload_file_main "${PARSE_MODE}" "{}" "${ID}" true
+            ' 1>| "${TMPFILE}"SUCCESS 2>| "${TMPFILE}"ERROR &
+            pid="${!}"
+
+            until [[ -f "${TMPFILE}"SUCCESS ]] || [[ -f "${TMPFILE}"ERORR ]]; do sleep 0.5; done
+            [[ ${PARSE_MODE} = parse ]] && _clear_line 1
+            _newline "\n"
+
+            until ! kill -0 "${pid}" 2>| /dev/null 1>&2; do
+                SUCCESS_STATUS="$(_count < "${TMPFILE}"SUCCESS)"
+                ERROR_STATUS="$(_count < "${TMPFILE}"ERROR)"
+                sleep 1
+                [[ $((SUCCESS_STATUS + ERROR_STATUS)) != "${TOTAL}" ]] &&
+                    _clear_line 1 && "${QUIET:-_print_center}" "justify" "Status" ": ${SUCCESS_STATUS} Uploaded | ${ERROR_STATUS} Failed" "="
+                TOTAL="$((SUCCESS_STATUS + ERROR_STATUS))"
+            done
+            SUCCESS_STATUS="$(_count < "${TMPFILE}"SUCCESS)"
+            ERROR_STATUS="$(_count < "${TMPFILE}"ERROR)"
+            ;;
+    esac
+    return 0
+}

--- a/bash/upload.bash
+++ b/bash/upload.bash
@@ -696,7 +696,8 @@ main() {
 
     [[ -z ${SELF_SOURCE} ]] && {
         UTILS_FOLDER="${UTILS_FOLDER:-${PWD}}"
-        { . "${UTILS_FOLDER}"/common-utils.bash && . "${UTILS_FOLDER}"/drive-utils.bash; } || { printf "Error: Unable to source util files.\n" && exit 1; }
+        { . "${UTILS_FOLDER}"/common-utils.bash && . "${UTILS_FOLDER}"/drive-utils.bash && . "${UTILS_FOLDER}"/upload-utils.bash; } ||
+            { printf "Error: Unable to source util files.\n" && exit 1; }
     }
 
     _check_bash_version && set -o errexit -o noclobber -o pipefail

--- a/bash/upload.bash
+++ b/bash/upload.bash
@@ -55,15 +55,12 @@ _short_help() {
 ###################################################
 _auto_update() {
     export REPO
-    (
-        _REPO="${REPO}"
-        command -v "${COMMAND_NAME}" 1> /dev/null &&
-            if [[ -n "${_REPO:+${COMMAND_NAME:+${INSTALL_PATH:+${TYPE:+${TYPE_VALUE}}}}}" ]]; then
-                current_time="$(printf "%(%s)T\\n" "-1")"
-                [[ $((LAST_UPDATE_TIME + AUTO_UPDATE_INTERVAL)) -lt ${current_time} ]] && _update
-                _update_value LAST_UPDATE_TIME "${current_time}"
-            fi
-    ) 2>| /dev/null 1>&2 &
+    command -v "${COMMAND_NAME}" 1> /dev/null &&
+        if [[ -n "${REPO:+${COMMAND_NAME:+${INSTALL_PATH:+${TYPE:+${TYPE_VALUE}}}}}" ]]; then
+            current_time="$(printf "%(%s)T\\n" "-1")"
+            [[ $((LAST_UPDATE_TIME + AUTO_UPDATE_INTERVAL)) -lt ${current_time} ]] && _update
+            _update_value LAST_UPDATE_TIME "${current_time}"
+        fi
     return 0
 }
 
@@ -712,27 +709,29 @@ main() {
             # unhide the cursor if hidden
             [[ -n ${SUPPORT_ANSI_ESCAPES} ]] && printf "\033[?25h"
 
-            # update the config with latest ACCESS_TOKEN and ACCESS_TOKEN_EXPIRY only if changed
-            NEW_ACCESS_TOKEN="$(. "${TMPFILE}_ACCESS_TOKEN" && printf "%s\n" "${ACCESS_TOKEN}")"
-            [[ ${INITIAL_ACCESS_TOKEN} = "${NEW_ACCESS_TOKEN}" ]] || {
-                _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-                _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+            [[ -f ${TMPFILE}_ACCESS_TOKEN ]] && {
+                # update the config with latest ACCESS_TOKEN and ACCESS_TOKEN_EXPIRY only if changed
+                . "${TMPFILE}_ACCESS_TOKEN"
+                [[ ${INITIAL_ACCESS_TOKEN} = "${ACCESS_TOKEN}" ]] || {
+                    _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
+                    _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                }
             }
 
             # grab all chidren processes of access token service
             # https://askubuntu.com/a/512872
-            token_service_pids="$(ps --ppid="${ACCESS_TOKEN_SERVICE_PID}" -o pid=)"
-            # first kill parent id, then children processes
-            kill "${ACCESS_TOKEN_SERVICE_PID}"
-            for pid in ${token_service_pids}; do
-                kill "${pid}"
-            done
+            [[ -n ${ACCESS_TOKEN_SERVICE_PID} ]] && {
+                token_service_pids="$(ps --ppid="${ACCESS_TOKEN_SERVICE_PID}" -o pid=)"
+                # first kill parent id, then children processes
+                kill "${ACCESS_TOKEN_SERVICE_PID}"
+            }
 
-            # manually kill all script children pids
+            # grab all script children pids
             script_children_pids="$(ps --ppid="${MAIN_PID}" -o pid=)"
-            for pid in ${script_children_pids}; do
-                kill "${pid}"
-            done
+
+            # kill all grabbed children processes
+            # shellcheck disable=SC2086
+            kill ${token_service_pids} ${script_children_pids}
 
             rm -f "${TMPFILE:?}"*
 
@@ -740,9 +739,9 @@ main() {
                 printf "\n\n%s\n" "Script exited manually."
                 kill -- -$$ &
             else
-                _auto_update
+                _auto_update &
             fi
-        } 2>| /dev/null || :
+        } 2>| /dev/null 1>&2 || :
         return 0
     }
 

--- a/bash/upload.bash
+++ b/bash/upload.bash
@@ -129,6 +129,35 @@ _version_info() {
 }
 
 ###################################################
+# Function to cleanup config file
+# Remove invalid access tokens on the basis of corresponding expiry
+# Globals: None
+# Arguments: 1
+#   ${1} = config file
+# Result: read description
+###################################################
+_cleanup_config() {
+    declare config="${1:?Error: Missing config}" values_regex
+
+    ! [ -f "${config}" ] && return 0
+
+    while read -r line; do
+        expiry_value_name="${line%%=*}"
+        token_value_name="${expiry_value_name%%_EXPIRY}"
+
+        : "${line##*=}" && : "${_%\"}" && expiry="${_#\"}"
+        [[ ${expiry} -le "$(printf "%(%s)T\\n" "-1")" ]] &&
+            values_regex="${values_regex:+${values_regex}|}${expiry_value_name}=\".*\"|${token_value_name}=\".*\""
+
+    done <<< "$(grep -F ACCESS_TOKEN_EXPIRY "${config}" || :)"
+
+    chmod +w "${config}" &&
+        printf "%s\n" "$(grep -Ev "^\$${values_regex:+|${values_regex}}" "${config}")" >| "${config}" &&
+        chmod -w "${config}"
+    return 0
+}
+
+###################################################
 # Process all arguments given to the script
 # Globals: 2 variable, 1 function
 #   Variable - HOME, CONFIG
@@ -739,7 +768,7 @@ main() {
                 printf "\n\n%s\n" "Script exited manually."
                 kill -- -$$ &
             else
-                _auto_update &
+                { _cleanup_config "${CONFIG}" && _auto_update; } &
             fi
         } 2>| /dev/null 1>&2 || :
         return 0

--- a/install.sh
+++ b/install.sh
@@ -165,22 +165,6 @@ _detect_profile() {
 }
 
 ###################################################
-# Alternative to dirname command
-# Globals: None
-# Arguments: 1
-#   ${1} = path of file or folder
-# Result: read description
-# Reference:
-#   https://github.com/dylanaraps/pure-sh-bible#file-paths
-###################################################
-_dirname() {
-    dir_dirname="${1:-.}"
-    dir_dirname="${dir_dirname%%"${dir_dirname##*[!/]}"}" && [ "${dir_dirname##*/*}" ] && dir_dirname=.
-    dir_dirname="${dir_dirname%/*}" && dir_dirname="${dir_dirname%%"${dir_dirname##*[!/]}"}"
-    printf '%s\n' "${dir_dirname:-/}"
-}
-
-###################################################
 # print column size
 # use bash or zsh or stty or tput
 ###################################################

--- a/merge.sh
+++ b/merge.sh
@@ -15,7 +15,7 @@ _merge() (
             sed -n 1p "${file}.${shell}"
             printf "%s\n" "SELF_SOURCE=\"true\""
             sed 1d common-utils."${shell}"
-            [ "${file}" = upload ] && sed 1d drive-utils."${shell}"
+            [ "${file}" = upload ] && sed 1d drive-utils."${shell}" && sed 1d upload-utils."${shell}"
             sed 1d "${file}.${shell}"
         } >| "release/g${file}"
         chmod +x "release/g${file}"

--- a/sh/common-utils.sh
+++ b/sh/common-utils.sh
@@ -129,24 +129,6 @@ _display_time() {
 }
 
 ###################################################
-# Extract ID from a googledrive folder/file url.
-# Globals: None
-# Arguments: 1
-#   ${1} = googledrive folder/file url.
-# Result: print extracted ID
-###################################################
-_extract_id() {
-    [ $# = 0 ] && printf "Missing arguments\n" && return 1
-    LC_ALL=C id_extract_id="${1}"
-    case "${id_extract_id}" in
-        *'drive.google.com'*'id='*) _tmp="${id_extract_id##*id=}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
-        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) _tmp="${id_extract_id##*\/d\/}" && _tmp="${_tmp%%\/*}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
-        *'drive.google.com'*'drive'*'folders'*) _tmp="${id_extract_id##*\/folders\/}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
-    esac
-    printf "%b" "${id_extract_id:+${id_extract_id}\n}"
-}
-
-###################################################
 # print column size
 # use zsh or stty or tput
 ###################################################

--- a/sh/release/gsync
+++ b/sh/release/gsync
@@ -130,24 +130,6 @@ _display_time() {
 }
 
 ###################################################
-# Extract ID from a googledrive folder/file url.
-# Globals: None
-# Arguments: 1
-#   ${1} = googledrive folder/file url.
-# Result: print extracted ID
-###################################################
-_extract_id() {
-    [ $# = 0 ] && printf "Missing arguments\n" && return 1
-    LC_ALL=C id_extract_id="${1}"
-    case "${id_extract_id}" in
-        *'drive.google.com'*'id='*) _tmp="${id_extract_id##*id=}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
-        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) _tmp="${id_extract_id##*\/d\/}" && _tmp="${_tmp%%\/*}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
-        *'drive.google.com'*'drive'*'folders'*) _tmp="${id_extract_id##*\/folders\/}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
-    esac
-    printf "%b" "${id_extract_id:+${id_extract_id}\n}"
-}
-
-###################################################
 # print column size
 # use zsh or stty or tput
 ###################################################

--- a/sh/release/gupload
+++ b/sh/release/gupload
@@ -1048,6 +1048,36 @@ _version_info() {
 }
 
 ###################################################
+# Function to cleanup config file
+# Remove invalid access tokens on the basis of corresponding expiry
+# Globals: None
+# Arguments: 1
+#   ${1} = config file
+# Result: read description
+###################################################
+_cleanup_config() {
+    config="${1:?Error: Missing config}" && unset values_regex _tmp
+
+    ! [ -f "${config}" ] && return 0
+
+    while read -r line <&4; do
+        expiry_value_name="${line%%=*}"
+        token_value_name="${expiry_value_name%%_EXPIRY}"
+
+        _tmp="${line##*=}" && _tmp="${_tmp%\"}" && expiry="${_tmp#\"}"
+        [ "${expiry}" -le "$(date +"%s")" ] &&
+            values_regex="${values_regex:+${values_regex}|}${expiry_value_name}=\".*\"|${token_value_name}=\".*\""
+    done 4<< EOF
+$(grep -F ACCESS_TOKEN_EXPIRY "${config}" || :)
+EOF
+
+    chmod +w "${config}" &&
+        printf "%s\n" "$(grep -Ev "^\$${values_regex:+|${values_regex}}" "${config}")" >| "${config}" &&
+        chmod -w "${config}"
+    return 0
+}
+
+###################################################
 # Process all arguments given to the script
 # Globals: 1 variable, 1 function
 #   Variable - HOME
@@ -1682,7 +1712,7 @@ main() {
                 printf "\n\n%s\n" "Script exited manually."
                 kill -9 -$$ &
             else
-                _auto_update &
+                { _cleanup_config "${CONFIG}" && _auto_update; } &
             fi
         } 2>| /dev/null 1>&2 || :
         return 0

--- a/sh/release/gupload
+++ b/sh/release/gupload
@@ -130,24 +130,6 @@ _display_time() {
 }
 
 ###################################################
-# Extract ID from a googledrive folder/file url.
-# Globals: None
-# Arguments: 1
-#   ${1} = googledrive folder/file url.
-# Result: print extracted ID
-###################################################
-_extract_id() {
-    [ $# = 0 ] && printf "Missing arguments\n" && return 1
-    LC_ALL=C id_extract_id="${1}"
-    case "${id_extract_id}" in
-        *'drive.google.com'*'id='*) _tmp="${id_extract_id##*id=}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
-        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) _tmp="${id_extract_id##*\/d\/}" && _tmp="${_tmp%%\/*}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
-        *'drive.google.com'*'drive'*'folders'*) _tmp="${id_extract_id##*\/folders\/}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
-    esac
-    printf "%b" "${id_extract_id:+${id_extract_id}\n}"
-}
-
-###################################################
 # print column size
 # use zsh or stty or tput
 ###################################################
@@ -348,100 +330,139 @@ _url_encode() (
   q = y ~ /[[:alnum:]]_.!~*\47()-]/ ? q y : q sprintf("%%%02X", z[y])
   print q}' "${1}"
 )
-# shellcheck source=/dev/null
 
 ###################################################
-# A simple wrapper to check tempfile for access token and make authorized oauth requests to drive api
+# Search for an existing file on gdrive with write permission.
+# Globals: 3 variables, 2 functions
+#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
+#   Functions - _url_encode, _json_value
+# Arguments: 2
+#   ${1} = file name
+#   ${2} = root dir id of file
+# Result: print file id else blank
+# Reference:
+#   https://developers.google.com/drive/api/v3/search-files
 ###################################################
-_api_request() {
-    . "${TMPFILE}_ACCESS_TOKEN"
+_check_existing_file() (
+    [ $# -lt 2 ] && printf "Missing arguments\n" && return 1
+    name_check_existing_file="${1##*/}" rootdir_check_existing_file="${2}"
+    unset query_check_existing_file response_check_existing_file id_check_existing_file
 
-    curl --compressed \
-        -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-        "${@}"
-}
+    "${EXTRA_LOG}" "justify" "Checking if file" " exists on gdrive.." "-" 1>&2
+    query_check_existing_file="$(_url_encode "name='${name_check_existing_file}' and '${rootdir_check_existing_file}' in parents and trashed=false and 'me' in writers")"
+
+    response_check_existing_file="$(_api_request "${CURL_PROGRESS_EXTRA}" \
+        "${API_URL}/drive/${API_VERSION}/files?q=${query_check_existing_file}&fields=files(id,name,mimeType)&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
+    _clear_line 1 1>&2
+
+    { printf "%s\n" "${response_check_existing_file}" | _json_value id 1 1 2>| /dev/null 1>&2 && printf "%s\n" "${response_check_existing_file}"; } || return 1
+    return 0
+)
 
 ###################################################
-# Method to regenerate access_token ( also updates in config ).
-# Make a request on https://www.googleapis.com/oauth2/""${API_VERSION}""/tokeninfo?access_token=${ACCESS_TOKEN} url and check if the given token is valid, if not generate one.
-# Globals: 9 variables, 2 functions
-#   Variables - CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, TOKEN_URL, CONFIG, API_URL, API_VERSION, QUIET, NO_UPDATE_TOKEN
-#   Functions - _update_config and _print_center
-# Result: Update access_token and expiry else print error
+# Copy/Clone a public gdrive file/folder from another/same gdrive account
+# Globals: 6 variables, 2 functions
+#   Variables - API_URL, API_VERSION, CURL_PROGRESS, LOG_FILE_ID, QUIET, ACCESS_TOKEN
+#   Functions - _print_center, _check_existing_file, _json_value, _bytes_to_human, _clear_line
+# Arguments: 5
+#   ${1} = update or upload ( upload type )
+#   ${2} = file id to upload
+#   ${3} = root dir id for file
+#   ${4} = name of file
+#   ${5} = size of file
+# Result: On
+#   Success - Upload/Update file and export FILE_ID
+#   Error - return 1
+# Reference:
+#   https://developers.google.com/drive/api/v2/reference/files/copy
 ###################################################
-_get_access_token_and_update() {
-    RESPONSE="${1:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
-    if ACCESS_TOKEN="$(printf "%s\n" "${RESPONSE}" | _json_value access_token 1 1)"; then
-        ACCESS_TOKEN_EXPIRY="$(($(date +"%s") + $(printf "%s\n" "${RESPONSE}" | _json_value expires_in 1 1) - 1))"
-        _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-        _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+_clone_file() {
+    [ $# -lt 5 ] && printf "Missing arguments\n" && return 1
+    job_clone_file="${1}" file_id_clone_file="${2}" file_root_id_clone_file="${3}" name_clone_file="${4}" size_clone_file="${5}"
+    unset post_data_clone_file response_clone_file readable_size_clone_file && STRING="Cloned"
+    post_data_clone_file="{\"parents\": [\"${file_root_id_clone_file}\"]}"
+    readable_size_clone_file="$(printf "%s\n" "${size_clone_file}" | _bytes_to_human)"
+
+    _print_center "justify" "${name_clone_file} " "| ${readable_size_clone_file}" "="
+
+    if [ "${job_clone_file}" = update ]; then
+        unset file_check_json_clone_file
+        # Check if file actually exists.
+        if file_check_json_clone_file="$(_check_existing_file "${name_clone_file}" "${file_root_id_clone_file}")"; then
+            if [ -n "${SKIP_DUPLICATES}" ]; then
+                _collect_file_info "${file_check_json_clone_file}" "${name_clone_file}" || return 1
+                _clear_line 1
+                "${QUIET:-_print_center}" "justify" "${name_clone_file}" " already exists." "=" && return 0
+            else
+                _print_center "justify" "Overwriting file.." "-"
+                { _file_id_clone_file="$(printf "%s\n" "${file_check_json_clone_file}" | _json_value id 1 1)" &&
+                    post_data_clone_file="$(_drive_info "${_file_id_clone_file}" "parents,writersCanShare")"; } ||
+                    { _error_logging_upload "${name_clone_file}" "${post_data_clone_file:-${file_check_json_clone_file}}"; }
+                if [ "${_file_id_clone_file}" != "${file_id_clone_file}" ]; then
+                    _api_request -s \
+                        -X DELETE \
+                        "${API_URL}/drive/${API_VERSION}/files/${_file_id_clone_file}?supportsAllDrives=true&includeItemsFromAllDrives=true" 2>| /dev/null 1>&2 || :
+                    STRING="Updated"
+                else
+                    _collect_file_info "${file_check_json_clone_file}" "${name_clone_file}" || return 1
+                fi
+            fi
+        else
+            _print_center "justify" "Cloning file.." "-"
+        fi
     else
-        "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
-        printf "%s\n" "${RESPONSE}" 1>&2
-        return 1
+        _print_center "justify" "Cloning file.." "-"
     fi
+
+    # shellcheck disable=SC2086
+    response_clone_file="$(_api_request ${CURL_PROGRESS} \
+        -X POST \
+        -H "Content-Type: application/json; charset=UTF-8" \
+        -d "${post_data_clone_file}" \
+        "${API_URL}/drive/${API_VERSION}/files/${file_id_clone_file}/copy?supportsAllDrives=true&includeItemsFromAllDrives=true" || :)"
+    for _ in 1 2 3; do _clear_line 1; done
+    _collect_file_info "${response_clone_file}" "${name_clone_file}" || return 1
+    "${QUIET:-_print_center}" "justify" "${name_clone_file} " "| ${readable_size_clone_file} | ${STRING}" "="
     return 0
 }
 
 ###################################################
-# A small function to get rootdir id for files in sub folder uploads
-# Globals: 1 variable, 1 function
-#   Variables - DIRIDS
-#   Functions - _dirname
-# Arguments: 1
-#   ${1} = filename
-# Result: read discription
+# Create/Check directory in google drive.
+# Globals: 3 variables, 2 functions
+#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
+#   Functions - _url_encode, _json_value
+# Arguments: 2
+#   ${1} = dir name
+#   ${2} = root dir id of given dir
+# Result: print folder id
+# Reference:
+#   https://developers.google.com/drive/api/v3/folder
 ###################################################
-_get_rootdir_id() {
-    file_gen_final_list="${1:?Error: give filename}"
-    rootdir_gen_final_list="$(_dirname "${file_gen_final_list}")"
-    temp_gen_final_list="$(printf "%s\n" "${DIRIDS:?Error: DIRIDS Missing}" | grep -F "|:_//_:|${rootdir_gen_final_list}|:_//_:|" || :)"
-    printf "%s\n" "${temp_gen_final_list%%"|:_//_:|${rootdir_gen_final_list}|:_//_:|"}"
-    return 0
-}
+_create_directory() {
+    [ $# -lt 2 ] && printf "Missing arguments\n" && return 1
+    dirname_create_directory="${1##*/}" rootdir_create_directory="${2}"
+    unset query_create_directory search_response_create_directory folder_id_create_directory
 
-###################################################
-# Used in collecting file properties from output json after a file has been uploaded/cloned
-# Also handles logging in log file if LOG_FILE_ID is set
-# Globals: 1 variables, 2 functions
-#   Variables - LOG_FILE_ID
-#   Functions - _error_logging_upload, _json_value
-# Arguments: 1
-#   ${1} = output jsom
-# Result: set fileid and link, save info to log file if required
-###################################################
-_collect_file_info() {
-    json_collect_file_info="${1}" info_collect_file_info=""
-    FILE_ID="$(printf "%s\n" "${json_collect_file_info}" | _json_value id 1 1)" || { _error_logging_upload "${2}" "${json_collect_file_info}"; }
-    { [ -z "${LOG_FILE_ID}" ] || [ -d "${LOG_FILE_ID}" ]; } && return 0
-    info_collect_file_info="$(
-        printf "%s\n" "Link: https://drive.google.com/open?id=${FILE_ID}"
-        printf "%s\n" "Name: $(printf "%s\n" "${json_collect_file_info}" | _json_value name 1 1 || :)"
-        printf "%s\n" "ID: ${FILE_ID}"
-        printf "%s\n" "Type: $(printf "%s\n" "${json_collect_file_info}" | _json_value mimeType 1 1 || :)"
-    )"
-    printf "%s\n" "${info_collect_file_info}" >> "${LOG_FILE_ID}"
-    return 0
-}
+    "${EXTRA_LOG}" "justify" "Creating GDRIVE DIR:" " ${dirname_create_directory}" "-" 1>&2
+    query_create_directory="$(_url_encode "mimeType='application/vnd.google-apps.folder' and name='${dirname_create_directory}' and trashed=false and '${rootdir_create_directory}' in parents")"
 
-###################################################
-# Error logging wrapper
-###################################################
-_error_logging_upload() {
-    log_error_logging_upload="${2}"
-    "${QUIET:-_print_center}" "justify" "Upload ERROR" ", ${1:-} not ${STRING:-uploaded}." "=" 1>&2
-    case "${log_error_logging_upload}" in
-        # https://github.com/rclone/rclone/issues/3857#issuecomment-573413789
-        *'"message": "User rate limit exceeded."'*)
-            printf "%s\n\n%s\n" "${log_error_logging_upload}" \
-                "Today's upload limit reached for this account. Use another account to upload or wait for tomorrow." 1>&2
-            # Never retry if upload limit reached
-            export RETRY=0
-            ;;
-        '' | *) printf "%s\n" "${log_error_logging_upload}" 1>&2 ;;
-    esac
-    printf "\n\n\n" 1>&2
-    return 1
+    search_response_create_directory="$(_api_request "${CURL_PROGRESS_EXTRA}" \
+        "${API_URL}/drive/${API_VERSION}/files?q=${query_create_directory}&fields=files(id)&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
+
+    if ! folder_id_create_directory="$(printf "%s\n" "${search_response_create_directory}" | _json_value id 1 1)"; then
+        unset create_folder_post_data_create_directory create_folder_response_create_directory
+        create_folder_post_data_create_directory="{\"mimeType\": \"application/vnd.google-apps.folder\",\"name\": \"${dirname_create_directory}\",\"parents\": [\"${rootdir_create_directory}\"]}"
+        create_folder_response_create_directory="$(_api_request "${CURL_PROGRESS_EXTRA}" \
+            -X POST \
+            -H "Content-Type: application/json; charset=UTF-8" \
+            -d "${create_folder_post_data_create_directory}" \
+            "${API_URL}/drive/${API_VERSION}/files?fields=id&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
+    fi
+    _clear_line 1 1>&2
+
+    { folder_id_create_directory="${folder_id_create_directory:-$(printf "%s\n" "${create_folder_response_create_directory}" | _json_value id 1 1)}" && printf "%s\n" "${folder_id_create_directory}"; } ||
+        { printf "%s\n" "${create_folder_response_create_directory}" 1>&2 && return 1; }
+    return 0
 }
 
 ###################################################
@@ -473,145 +494,44 @@ _drive_info() {
 }
 
 ###################################################
-# Search for an existing file on gdrive with write permission.
-# Globals: 3 variables, 2 functions
-#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
-#   Functions - _url_encode, _json_value
-# Arguments: 2
-#   ${1} = file name
-#   ${2} = root dir id of file
-# Result: print file id else blank
-# Reference:
-#   https://developers.google.com/drive/api/v3/search-files
+# Extract ID from a googledrive folder/file url.
+# Globals: None
+# Arguments: 1
+#   ${1} = googledrive folder/file url.
+# Result: print extracted ID
 ###################################################
-_check_existing_file() (
-    [ $# -lt 2 ] && printf "Missing arguments\n" && return 1
-    name_check_existing_file="${1##*/}" rootdir_check_existing_file="${2}"
-    unset query_check_existing_file response_check_existing_file id_check_existing_file
-
-    "${EXTRA_LOG}" "justify" "Checking if file" " exists on gdrive.." "-" 1>&2
-    query_check_existing_file="$(_url_encode "name='${name_check_existing_file}' and '${rootdir_check_existing_file}' in parents and trashed=false and 'me' in writers")"
-
-    response_check_existing_file="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-        "${API_URL}/drive/${API_VERSION}/files?q=${query_check_existing_file}&fields=files(id,name,mimeType)&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
-    _clear_line 1 1>&2
-
-    { printf "%s\n" "${response_check_existing_file}" | _json_value id 1 1 2>| /dev/null 1>&2 && printf "%s\n" "${response_check_existing_file}"; } || return 1
-    return 0
-)
-
-###################################################
-# Create/Check directory in google drive.
-# Globals: 3 variables, 2 functions
-#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
-#   Functions - _url_encode, _json_value
-# Arguments: 2
-#   ${1} = dir name
-#   ${2} = root dir id of given dir
-# Result: print folder id
-# Reference:
-#   https://developers.google.com/drive/api/v3/folder
-###################################################
-_create_directory() (
-    [ $# -lt 2 ] && printf "Missing arguments\n" && return 1
-    dirname_create_directory="${1##*/}" rootdir_create_directory="${2}"
-    unset query_create_directory search_response_create_directory folder_id_create_directory
-
-    "${EXTRA_LOG}" "justify" "Creating GDRIVE DIR:" " ${dirname_create_directory}" "-" 1>&2
-    query_create_directory="$(_url_encode "mimeType='application/vnd.google-apps.folder' and name='${dirname_create_directory}' and trashed=false and '${rootdir_create_directory}' in parents")"
-
-    search_response_create_directory="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-        "${API_URL}/drive/${API_VERSION}/files?q=${query_create_directory}&fields=files(id)&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
-
-    if ! folder_id_create_directory="$(printf "%s\n" "${search_response_create_directory}" | _json_value id 1 1)"; then
-        unset create_folder_post_data_create_directory create_folder_response_create_directory
-        create_folder_post_data_create_directory="{\"mimeType\": \"application/vnd.google-apps.folder\",\"name\": \"${dirname_create_directory}\",\"parents\": [\"${rootdir_create_directory}\"]}"
-        create_folder_response_create_directory="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-            -X POST \
-            -H "Content-Type: application/json; charset=UTF-8" \
-            -d "${create_folder_post_data_create_directory}" \
-            "${API_URL}/drive/${API_VERSION}/files?fields=id&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
-    fi
-    _clear_line 1 1>&2
-
-    { folder_id_create_directory="${folder_id_create_directory:-$(printf "%s\n" "${create_folder_response_create_directory}" | _json_value id 1 1)}" && printf "%s\n" "${folder_id_create_directory}"; } ||
-        { printf "%s\n" "${create_folder_response_create_directory}" 1>&2 && return 1; }
-    return 0
-)
-
-###################################################
-# Sub functions for _upload_file function - Start
-# generate resumable upload link
-_generate_upload_link() {
-    "${EXTRA_LOG}" "justify" "Generating upload link.." "-" 1>&2
-    uploadlink_upload_file="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-        -X "${request_method_upload_file}" \
-        -H "Content-Type: application/json; charset=UTF-8" \
-        -H "X-Upload-Content-Type: ${mime_type_upload_file}" \
-        -H "X-Upload-Content-Length: ${inputsize_upload_file}" \
-        -d "$postdata_upload_file" \
-        "${url_upload_file}" \
-        -D - || :)" && _clear_line 1 1>&2
-    _clear_line 1 1>&2
-
-    case "${uploadlink_upload_file}" in
-        *'ocation: '*'upload_id'*) uploadlink_upload_file="$(printf "%s\n" "${uploadlink_upload_file##*[L,l]ocation: }" | while read -r line; do printf "%s\n" "${line%%$(printf '\r')}" && break; done)" && return 0 ;;
-        '' | *) return 1 ;;
+_extract_id() {
+    [ $# = 0 ] && printf "Missing arguments\n" && return 1
+    LC_ALL=C id_extract_id="${1}"
+    case "${id_extract_id}" in
+        *'drive.google.com'*'id='*) _tmp="${id_extract_id##*id=}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
+        *'drive.google.com'*'file/d/'* | 'http'*'docs.google.com'*'/d/'*) _tmp="${id_extract_id##*\/d\/}" && _tmp="${_tmp%%\/*}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
+        *'drive.google.com'*'drive'*'folders'*) _tmp="${id_extract_id##*\/folders\/}" && _tmp="${_tmp%%\?*}" && id_extract_id="${_tmp%%\&*}" ;;
     esac
-
-    return 0
+    printf "%b" "${id_extract_id:+${id_extract_id}\n}"
 }
 
-# Curl command to push the file to google drive.
-_upload_file_from_uri() {
-    _print_center "justify" "Uploading.." "-"
-    # shellcheck disable=SC2086 # Because unnecessary to another check because ${CURL_PROGRESS} won't be anything problematic.
-    upload_body_upload_file="$(_api_request ${CURL_PROGRESS} \
-        -X PUT \
-        -H "Content-Type: ${mime_type_upload_file}" \
-        -H "Content-Length: ${content_length_upload_file}" \
-        -H "Slug: ${slug_upload_file}" \
-        -T "${input_upload_file}" \
-        -o- \
-        --url "${uploadlink_upload_file}" \
-        --globoff \
-        ${CURL_SPEED} ${resume_args1} ${resume_args2} \
-        -H "${resume_args3}" || :)"
-    [ -z "${VERBOSE_PROGRESS}" ] && for _ in 1 2; do _clear_line 1; done && "${1:-:}"
-    return 0
-}
-
-# logging in case of successful upload
-_normal_logging_upload() {
-    [ -z "${VERBOSE_PROGRESS}" ] && _clear_line 1
-    "${QUIET:-_print_center}" "justify" "${slug_upload_file} " "| ${readable_size_upload_file} | ${STRING}" "="
-    return 0
-}
-
-# Tempfile Used for resuming interrupted uploads
-_log_upload_session() {
-    [ "${inputsize_upload_file}" -gt 1000000 ] && printf "%s\n" "${uploadlink_upload_file}" >| "${__file_upload_file}"
-    return 0
-}
-
-# remove upload session
-_remove_upload_session() {
-    rm -f "${__file_upload_file}"
-    return 0
-}
-
-# wrapper to fully upload a file from scratch
-_full_upload() {
-    _generate_upload_link || { _error_logging_upload "${slug_upload_file}" "${uploadlink_upload_file}"; }
-    _log_upload_session
-    _upload_file_from_uri
-    _collect_file_info "${upload_body_upload_file}" "${slug_upload_file}" || return 1
-    _normal_logging_upload
-    _remove_upload_session
-    return 0
-}
-# Sub functions for _upload_file function - End
 ###################################################
+# Method to regenerate access_token ( also updates in config ).
+# Make a request on https://www.googleapis.com/oauth2/""${API_VERSION}""/tokeninfo?access_token=${ACCESS_TOKEN} url and check if the given token is valid, if not generate one.
+# Globals: 9 variables, 2 functions
+#   Variables - CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, TOKEN_URL, CONFIG, API_URL, API_VERSION, QUIET, NO_UPDATE_TOKEN
+#   Functions - _update_config and _print_center
+# Result: Update access_token and expiry else print error
+###################################################
+_get_access_token_and_update() {
+    RESPONSE="${1:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
+    if ACCESS_TOKEN="$(printf "%s\n" "${RESPONSE}" | _json_value access_token 1 1)"; then
+        ACCESS_TOKEN_EXPIRY="$(($(date +"%s") + $(printf "%s\n" "${RESPONSE}" | _json_value expires_in 1 1) - 1))"
+        _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
+        _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+    else
+        "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
+        printf "%s\n" "${RESPONSE}" 1>&2
+        return 1
+    fi
+    return 0
+}
 
 ###################################################
 # Upload ( Create/Update ) files on gdrive.
@@ -729,6 +649,182 @@ _upload_file() {
 }
 
 ###################################################
+# Sub functions for _upload_file function - Start
+# generate resumable upload link
+_generate_upload_link() {
+    "${EXTRA_LOG}" "justify" "Generating upload link.." "-" 1>&2
+    uploadlink_upload_file="$(_api_request "${CURL_PROGRESS_EXTRA}" \
+        -X "${request_method_upload_file}" \
+        -H "Content-Type: application/json; charset=UTF-8" \
+        -H "X-Upload-Content-Type: ${mime_type_upload_file}" \
+        -H "X-Upload-Content-Length: ${inputsize_upload_file}" \
+        -d "$postdata_upload_file" \
+        "${url_upload_file}" \
+        -D - || :)" && _clear_line 1 1>&2
+    _clear_line 1 1>&2
+
+    case "${uploadlink_upload_file}" in
+        *'ocation: '*'upload_id'*) uploadlink_upload_file="$(printf "%s\n" "${uploadlink_upload_file##*[L,l]ocation: }" | while read -r line; do printf "%s\n" "${line%%$(printf '\r')}" && break; done)" && return 0 ;;
+        '' | *) return 1 ;;
+    esac
+
+    return 0
+}
+
+# Curl command to push the file to google drive.
+_upload_file_from_uri() {
+    _print_center "justify" "Uploading.." "-"
+    # shellcheck disable=SC2086 # Because unnecessary to another check because ${CURL_PROGRESS} won't be anything problematic.
+    upload_body_upload_file="$(_api_request ${CURL_PROGRESS} \
+        -X PUT \
+        -H "Content-Type: ${mime_type_upload_file}" \
+        -H "Content-Length: ${content_length_upload_file}" \
+        -H "Slug: ${slug_upload_file}" \
+        -T "${input_upload_file}" \
+        -o- \
+        --url "${uploadlink_upload_file}" \
+        --globoff \
+        ${CURL_SPEED} ${resume_args1} ${resume_args2} \
+        -H "${resume_args3}" || :)"
+    [ -z "${VERBOSE_PROGRESS}" ] && for _ in 1 2; do _clear_line 1; done && "${1:-:}"
+    return 0
+}
+
+# logging in case of successful upload
+_normal_logging_upload() {
+    [ -z "${VERBOSE_PROGRESS}" ] && _clear_line 1
+    "${QUIET:-_print_center}" "justify" "${slug_upload_file} " "| ${readable_size_upload_file} | ${STRING}" "="
+    return 0
+}
+
+# Tempfile Used for resuming interrupted uploads
+_log_upload_session() {
+    [ "${inputsize_upload_file}" -gt 1000000 ] && printf "%s\n" "${uploadlink_upload_file}" >| "${__file_upload_file}"
+    return 0
+}
+
+# remove upload session
+_remove_upload_session() {
+    rm -f "${__file_upload_file}"
+    return 0
+}
+
+# wrapper to fully upload a file from scratch
+_full_upload() {
+    _generate_upload_link || { _error_logging_upload "${slug_upload_file}" "${uploadlink_upload_file}"; }
+    _log_upload_session
+    _upload_file_from_uri
+    _collect_file_info "${upload_body_upload_file}" "${slug_upload_file}" || return 1
+    _normal_logging_upload
+    _remove_upload_session
+    return 0
+}
+# Sub functions for _upload_file function - End
+###################################################
+
+###################################################
+# Share a gdrive file/folder
+# Globals: 3 variables, 4 functions
+#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
+#   Functions - _url_encode, _json_value, _print_center, _clear_line
+# Arguments: 2
+#   ${1} = gdrive ID of folder/file
+#   ${2} = Email to which file will be shared ( optional )
+# Result: read description
+# Reference:
+#   https://developers.google.com/drive/api/v3/manage-sharing
+###################################################
+_share_id() {
+    [ $# -lt 2 ] && printf "Missing arguments\n" && return 1
+    id_share_id="${1}" share_email_share_id="${2}" role_share_id="reader" type_share_id="${share_email_share_id:+user}"
+    unset post_data_share_id response_share_id
+
+    "${EXTRA_LOG}" "justify" "Sharing.." "-" 1>&2
+    post_data_share_id="{\"role\":\"${role_share_id}\",\"type\":\"${type_share_id:-anyone}\"${share_email_share_id:+,\\\"emailAddress\\\":\\\"${share_email_share_id}\\\"}}"
+
+    response_share_id="$(_api_request "${CURL_PROGRESS_EXTRA}" \
+        -X POST \
+        -H "Content-Type: application/json; charset=UTF-8" \
+        -d "${post_data_share_id}" \
+        "${API_URL}/drive/${API_VERSION}/files/${id_share_id}/permissions?supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
+    _clear_line 1 1>&2
+
+    { printf "%s\n" "${response_share_id}" | _json_value id 1 1 2>| /dev/null 1>&2 && return 0; } ||
+        { printf "%s\n" "Error: Cannot Share." 1>&2 && printf "%s\n" "${response_share_id}" 1>&2 && return 1; }
+}
+# shellcheck source=/dev/null
+
+###################################################
+# A simple wrapper to check tempfile for access token and make authorized oauth requests to drive api
+###################################################
+_api_request() {
+    . "${TMPFILE}_ACCESS_TOKEN"
+
+    curl --compressed \
+        -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+        "${@}"
+}
+
+###################################################
+# Used in collecting file properties from output json after a file has been uploaded/cloned
+# Also handles logging in log file if LOG_FILE_ID is set
+# Globals: 1 variables, 2 functions
+#   Variables - LOG_FILE_ID
+#   Functions - _error_logging_upload, _json_value
+# Arguments: 1
+#   ${1} = output jsom
+# Result: set fileid and link, save info to log file if required
+###################################################
+_collect_file_info() {
+    json_collect_file_info="${1}" info_collect_file_info=""
+    FILE_ID="$(printf "%s\n" "${json_collect_file_info}" | _json_value id 1 1)" || { _error_logging_upload "${2}" "${json_collect_file_info}"; }
+    { [ -z "${LOG_FILE_ID}" ] || [ -d "${LOG_FILE_ID}" ]; } && return 0
+    info_collect_file_info="Link: https://drive.google.com/open?id=${FILE_ID}
+Name: $(printf "%s\n" "${json_collect_file_info}" | _json_value name 1 1 || :)
+ID: ${FILE_ID}
+Type: $(printf "%s\n" "${json_collect_file_info}" | _json_value mimeType 1 1 || :)"
+    printf "%s\n\n" "${info_collect_file_info}" >> "${LOG_FILE_ID}"
+    return 0
+}
+
+###################################################
+# Error logging wrapper
+###################################################
+_error_logging_upload() {
+    log_error_logging_upload="${2}"
+    "${QUIET:-_print_center}" "justify" "Upload ERROR" ", ${1:-} not ${STRING:-uploaded}." "=" 1>&2
+    case "${log_error_logging_upload}" in
+        # https://github.com/rclone/rclone/issues/3857#issuecomment-573413789
+        *'"message": "User rate limit exceeded."'*)
+            printf "%s\n\n%s\n" "${log_error_logging_upload}" \
+                "Today's upload limit reached for this account. Use another account to upload or wait for tomorrow." 1>&2
+            # Never retry if upload limit reached
+            export RETRY=0
+            ;;
+        '' | *) printf "%s\n" "${log_error_logging_upload}" 1>&2 ;;
+    esac
+    printf "\n\n\n" 1>&2
+    return 1
+}
+
+###################################################
+# A small function to get rootdir id for files in sub folder uploads
+# Globals: 1 variable, 1 function
+#   Variables - DIRIDS
+#   Functions - _dirname
+# Arguments: 1
+#   ${1} = filename
+# Result: read discription
+###################################################
+_get_rootdir_id() {
+    file_gen_final_list="${1:?Error: give filename}"
+    rootdir_gen_final_list="$(_dirname "${file_gen_final_list}")"
+    temp_gen_final_list="$(printf "%s\n" "${DIRIDS:?Error: DIRIDS Missing}" | grep -F "|:_//_:|${rootdir_gen_final_list}|:_//_:|" || :)"
+    printf "%s\n" "${temp_gen_final_list%%"|:_//_:|${rootdir_gen_final_list}|:_//_:|"}"
+    return 0
+}
+
+###################################################
 # A extra wrapper for _upload_file function to properly handle retries
 # also handle uploads in case uploading from folder
 # Globals: 3 variables, 1 function
@@ -820,104 +916,6 @@ EOF
             ;;
     esac
     return 0
-}
-
-###################################################
-# Copy/Clone a public gdrive file/folder from another/same gdrive account
-# Globals: 6 variables, 2 functions
-#   Variables - API_URL, API_VERSION, CURL_PROGRESS, LOG_FILE_ID, QUIET, ACCESS_TOKEN
-#   Functions - _print_center, _check_existing_file, _json_value, _bytes_to_human, _clear_line
-# Arguments: 5
-#   ${1} = update or upload ( upload type )
-#   ${2} = file id to upload
-#   ${3} = root dir id for file
-#   ${4} = name of file
-#   ${5} = size of file
-# Result: On
-#   Success - Upload/Update file and export FILE_ID
-#   Error - return 1
-# Reference:
-#   https://developers.google.com/drive/api/v2/reference/files/copy
-###################################################
-_clone_file() {
-    [ $# -lt 5 ] && printf "Missing arguments\n" && return 1
-    job_clone_file="${1}" file_id_clone_file="${2}" file_root_id_clone_file="${3}" name_clone_file="${4}" size_clone_file="${5}"
-    unset post_data_clone_file response_clone_file readable_size_clone_file && STRING="Cloned"
-    post_data_clone_file="{\"parents\": [\"${file_root_id_clone_file}\"]}"
-    readable_size_clone_file="$(printf "%s\n" "${size_clone_file}" | _bytes_to_human)"
-
-    _print_center "justify" "${name_clone_file} " "| ${readable_size_clone_file}" "="
-
-    if [ "${job_clone_file}" = update ]; then
-        unset file_check_json_clone_file
-        # Check if file actually exists.
-        if file_check_json_clone_file="$(_check_existing_file "${name_clone_file}" "${file_root_id_clone_file}")"; then
-            if [ -n "${SKIP_DUPLICATES}" ]; then
-                _collect_file_info "${file_check_json_clone_file}" "${name_clone_file}" || return 1
-                _clear_line 1
-                "${QUIET:-_print_center}" "justify" "${name_clone_file}" " already exists." "=" && return 0
-            else
-                _print_center "justify" "Overwriting file.." "-"
-                { _file_id_clone_file="$(printf "%s\n" "${file_check_json_clone_file}" | _json_value id 1 1)" &&
-                    post_data_clone_file="$(_drive_info "${_file_id_clone_file}" "parents,writersCanShare")"; } ||
-                    { _error_logging_upload "${name_clone_file}" "${post_data_clone_file:-${file_check_json_clone_file}}"; }
-                if [ "${_file_id_clone_file}" != "${file_id_clone_file}" ]; then
-                    _api_request -s \
-                        -X DELETE \
-                        "${API_URL}/drive/${API_VERSION}/files/${_file_id_clone_file}?supportsAllDrives=true&includeItemsFromAllDrives=true" 2>| /dev/null 1>&2 || :
-                    STRING="Updated"
-                else
-                    _collect_file_info "${file_check_json_clone_file}" "${name_clone_file}" || return 1
-                fi
-            fi
-        else
-            _print_center "justify" "Cloning file.." "-"
-        fi
-    else
-        _print_center "justify" "Cloning file.." "-"
-    fi
-
-    # shellcheck disable=SC2086
-    response_clone_file="$(_api_request ${CURL_PROGRESS} \
-        -X POST \
-        -H "Content-Type: application/json; charset=UTF-8" \
-        -d "${post_data_clone_file}" \
-        "${API_URL}/drive/${API_VERSION}/files/${file_id_clone_file}/copy?supportsAllDrives=true&includeItemsFromAllDrives=true" || :)"
-    for _ in 1 2 3; do _clear_line 1; done
-    _collect_file_info "${response_clone_file}" "${name_clone_file}" || return 1
-    "${QUIET:-_print_center}" "justify" "${name_clone_file} " "| ${readable_size_clone_file} | ${STRING}" "="
-    return 0
-}
-
-###################################################
-# Share a gdrive file/folder
-# Globals: 3 variables, 4 functions
-#   Variables - API_URL, API_VERSION, ACCESS_TOKEN
-#   Functions - _url_encode, _json_value, _print_center, _clear_line
-# Arguments: 2
-#   ${1} = gdrive ID of folder/file
-#   ${2} = Email to which file will be shared ( optional )
-# Result: read description
-# Reference:
-#   https://developers.google.com/drive/api/v3/manage-sharing
-###################################################
-_share_id() {
-    [ $# -lt 2 ] && printf "Missing arguments\n" && return 1
-    id_share_id="${1}" share_email_share_id="${2}" role_share_id="reader" type_share_id="${share_email_share_id:+user}"
-    unset post_data_share_id response_share_id
-
-    "${EXTRA_LOG}" "justify" "Sharing.." "-" 1>&2
-    post_data_share_id="{\"role\":\"${role_share_id}\",\"type\":\"${type_share_id:-anyone}\"${share_email_share_id:+,\\\"emailAddress\\\":\\\"${share_email_share_id}\\\"}}"
-
-    response_share_id="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-        -X POST \
-        -H "Content-Type: application/json; charset=UTF-8" \
-        -d "${post_data_share_id}" \
-        "${API_URL}/drive/${API_VERSION}/files/${id_share_id}/permissions?supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
-    _clear_line 1 1>&2
-
-    { printf "%s\n" "${response_share_id}" | _json_value id 1 1 2>| /dev/null 1>&2 && return 0; } ||
-        { printf "%s\n" "Error: Cannot Share." 1>&2 && printf "%s\n" "${response_share_id}" 1>&2 && return 1; }
 }
 # Upload a file to Google Drive
 # shellcheck source=/dev/null
@@ -1639,7 +1637,7 @@ main() {
     [ $# = 0 ] && _short_help
 
     if [ -z "${SELF_SOURCE}" ]; then
-        UTILS_FOLDER="${UTILS_FOLDER:-${PWD}}" && SOURCE_UTILS=". '${UTILS_FOLDER}/common-utils.sh' && . '${UTILS_FOLDER}/drive-utils.sh'"
+        UTILS_FOLDER="${UTILS_FOLDER:-${PWD}}" && SOURCE_UTILS=". '${UTILS_FOLDER}/common-utils.sh' && . '${UTILS_FOLDER}/drive-utils.sh' && . '${UTILS_FOLDER}/upload-utils.sh'"
         eval "${SOURCE_UTILS}" || { printf "Error: Unable to source util files.\n" && exit 1; }
     else
         SOURCE_UTILS="SOURCED_GUPLOAD=true . \"$(cd "$(_dirname "${0}")" && pwd)/${0##*\/}\"" && eval "${SOURCE_UTILS}"

--- a/sh/release/gupload
+++ b/sh/release/gupload
@@ -973,15 +973,12 @@ _short_help() {
 ###################################################
 _auto_update() {
     export REPO
-    (
-        _REPO="${REPO}"
-        command -v "${COMMAND_NAME}" 1> /dev/null &&
-            if [ -n "${_REPO:+${COMMAND_NAME:+${INSTALL_PATH:+${TYPE:+${TYPE_VALUE}}}}}" ]; then
-                current_time="$(date +'%s')"
-                [ "$((LAST_UPDATE_TIME + AUTO_UPDATE_INTERVAL))" -lt "$(date +'%s')" ] && _update
-                _update_value LAST_UPDATE_TIME "${current_time}"
-            fi
-    ) 2>| /dev/null 1>&2 &
+    command -v "${COMMAND_NAME}" 1> /dev/null &&
+        if [ -n "${REPO:+${COMMAND_NAME:+${INSTALL_PATH:+${TYPE:+${TYPE_VALUE}}}}}" ]; then
+            current_time="$(date +'%s')"
+            [ "$((LAST_UPDATE_TIME + AUTO_UPDATE_INTERVAL))" -lt "$(date +'%s')" ] && _update
+            _update_value LAST_UPDATE_TIME "${current_time}"
+        fi
     return 0
 }
 
@@ -1656,26 +1653,28 @@ main() {
             [ -n "${SUPPORT_ANSI_ESCAPES}" ] && printf "\033[?25h"
 
             # update the config with latest ACCESS_TOKEN and ACCESS_TOKEN_EXPIRY only if changed
-            NEW_ACCESS_TOKEN="$(. "${TMPFILE}_ACCESS_TOKEN" && printf "%s\n" "${ACCESS_TOKEN}")"
-            [ "${INITIAL_ACCESS_TOKEN}" = "${NEW_ACCESS_TOKEN}" ] || {
-                _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-                _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+            [ -f "${TMPFILE}_ACCESS_TOKEN" ] && {
+                . "${TMPFILE}_ACCESS_TOKEN"
+                [ "${INITIAL_ACCESS_TOKEN}" = "${ACCESS_TOKEN}" ] || {
+                    _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
+                    _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                }
             }
 
             # grab all chidren processes of access token service
             # https://askubuntu.com/a/512872
-            token_service_pids="$(ps --ppid="${ACCESS_TOKEN_SERVICE_PID}" -o pid=)"
-            # first kill parent id, then children processes
-            kill "${ACCESS_TOKEN_SERVICE_PID}"
-            for pid in ${token_service_pids}; do
-                kill "${pid}"
-            done
+            [ -n "${ACCESS_TOKEN_SERVICE_PID}" ] && {
+                token_service_pids="$(ps --ppid="${ACCESS_TOKEN_SERVICE_PID}" -o pid=)"
+                # first kill parent id, then children processes
+                kill "${ACCESS_TOKEN_SERVICE_PID}"
+            }
 
-            # manually kill all script children pids
+            # grab all script children pids
             script_children_pids="$(ps --ppid="${MAIN_PID}" -o pid=)"
-            for pid in ${script_children_pids}; do
-                kill "${pid}"
-            done
+
+            # kill all grabbed children processes
+            # shellcheck disable=SC2086
+            kill ${token_service_pids} ${script_children_pids}
 
             rm -f "${TMPFILE:?}"*
 
@@ -1683,9 +1682,9 @@ main() {
                 printf "\n\n%s\n" "Script exited manually."
                 kill -9 -$$ &
             else
-                _auto_update
+                _auto_update &
             fi
-        } 2>| /dev/null || :
+        } 2>| /dev/null 1>&2 || :
         return 0
     }
 

--- a/sh/upload-utils.sh
+++ b/sh/upload-utils.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env sh
+# shellcheck source=/dev/null
+
+###################################################
+# A simple wrapper to check tempfile for access token and make authorized oauth requests to drive api
+###################################################
+_api_request() {
+    . "${TMPFILE}_ACCESS_TOKEN"
+
+    curl --compressed \
+        -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+        "${@}"
+}
+
+###################################################
+# Used in collecting file properties from output json after a file has been uploaded/cloned
+# Also handles logging in log file if LOG_FILE_ID is set
+# Globals: 1 variables, 2 functions
+#   Variables - LOG_FILE_ID
+#   Functions - _error_logging_upload, _json_value
+# Arguments: 1
+#   ${1} = output jsom
+# Result: set fileid and link, save info to log file if required
+###################################################
+_collect_file_info() {
+    json_collect_file_info="${1}" info_collect_file_info=""
+    FILE_ID="$(printf "%s\n" "${json_collect_file_info}" | _json_value id 1 1)" || { _error_logging_upload "${2}" "${json_collect_file_info}"; }
+    { [ -z "${LOG_FILE_ID}" ] || [ -d "${LOG_FILE_ID}" ]; } && return 0
+    info_collect_file_info="Link: https://drive.google.com/open?id=${FILE_ID}
+Name: $(printf "%s\n" "${json_collect_file_info}" | _json_value name 1 1 || :)
+ID: ${FILE_ID}
+Type: $(printf "%s\n" "${json_collect_file_info}" | _json_value mimeType 1 1 || :)"
+    printf "%s\n\n" "${info_collect_file_info}" >> "${LOG_FILE_ID}"
+    return 0
+}
+
+###################################################
+# Error logging wrapper
+###################################################
+_error_logging_upload() {
+    log_error_logging_upload="${2}"
+    "${QUIET:-_print_center}" "justify" "Upload ERROR" ", ${1:-} not ${STRING:-uploaded}." "=" 1>&2
+    case "${log_error_logging_upload}" in
+        # https://github.com/rclone/rclone/issues/3857#issuecomment-573413789
+        *'"message": "User rate limit exceeded."'*)
+            printf "%s\n\n%s\n" "${log_error_logging_upload}" \
+                "Today's upload limit reached for this account. Use another account to upload or wait for tomorrow." 1>&2
+            # Never retry if upload limit reached
+            export RETRY=0
+            ;;
+        '' | *) printf "%s\n" "${log_error_logging_upload}" 1>&2 ;;
+    esac
+    printf "\n\n\n" 1>&2
+    return 1
+}
+
+###################################################
+# A small function to get rootdir id for files in sub folder uploads
+# Globals: 1 variable, 1 function
+#   Variables - DIRIDS
+#   Functions - _dirname
+# Arguments: 1
+#   ${1} = filename
+# Result: read discription
+###################################################
+_get_rootdir_id() {
+    file_gen_final_list="${1:?Error: give filename}"
+    rootdir_gen_final_list="$(_dirname "${file_gen_final_list}")"
+    temp_gen_final_list="$(printf "%s\n" "${DIRIDS:?Error: DIRIDS Missing}" | grep -F "|:_//_:|${rootdir_gen_final_list}|:_//_:|" || :)"
+    printf "%s\n" "${temp_gen_final_list%%"|:_//_:|${rootdir_gen_final_list}|:_//_:|"}"
+    return 0
+}
+
+###################################################
+# A extra wrapper for _upload_file function to properly handle retries
+# also handle uploads in case uploading from folder
+# Globals: 3 variables, 1 function
+#   Variables - RETRY, UPLOAD_MODE and ACCESS_TOKEN
+#   Functions - _upload_file
+# Arguments: 3
+#   ${1} = parse or norparse
+#   ${2} = file path
+#   ${3} = if ${1} != parse; gdrive folder id to upload; fi
+# Result: set SUCCESS var on success
+###################################################
+_upload_file_main() {
+    [ $# -lt 2 ] && printf "Missing arguments\n" && return 1
+    file_upload_file_main="${2}" sleep_upload_file_main=0
+    { [ "${1}" = parse ] && dirid_upload_file_main="$(_get_rootdir_id "${file_upload_file_main}")"; } || dirid_upload_file_main="${3}"
+
+    retry_upload_file_main="${RETRY:-0}" && unset RETURN_STATUS
+    until [ "${retry_upload_file_main}" -le 0 ] && [ -n "${RETURN_STATUS}" ]; do
+        if [ -n "${4}" ]; then
+            _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" 2>| /dev/null 1>&2 && RETURN_STATUS=1 && break
+        else
+            _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" && RETURN_STATUS=1 && break
+        fi
+        sleep "$((sleep_upload_file_main += 1))" # on every retry, sleep the times of retry it is, e.g for 1st, sleep 1, for 2nd, sleep 2
+        RETURN_STATUS=2 retry_upload_file_main="$((retry_upload_file_main - 1))" && continue
+    done
+    printf "%b" "${4:+${RETURN_STATUS}\n}" 1>&"${RETURN_STATUS}"
+    return 0
+}
+
+###################################################
+# Upload all files in the given folder, parallelly or non-parallely and show progress
+# Globals: 7 variables, 3 functions
+#   Variables - VERBOSE, VERBOSE_PROGRESS, NO_OF_PARALLEL_JOBS, NO_OF_FILES, TMPFILE, UTILS_FOLDER and QUIET
+#   Functions - _clear_line, _newline, _print_center and _upload_file_main
+# Arguments: 4
+#   ${1} = parallel or normal
+#   ${2} = parse or norparse
+#   ${3} = filenames with full path
+#   ${4} = if ${2} != parse; then gdrive folder id to upload; fi
+# Result: read discription, set SUCCESS_STATUS & ERROR_STATUS
+###################################################
+_upload_folder() {
+    [ $# -lt 3 ] && printf "Missing arguments\n" && return 1
+    mode_upload_folder="${1}" PARSE_MODE="${2}" files_upload_folder="${3}" ID="${4:-}" && export PARSE_MODE ID
+    case "${mode_upload_folder}" in
+        normal)
+            [ "${PARSE_MODE}" = parse ] && _clear_line 1 && _newline "\n"
+
+            while read -r file <&4; do
+                _upload_file_main "${PARSE_MODE}" "${file}" "${ID}"
+                : "$((RETURN_STATUS < 2 ? (SUCCESS_STATUS += 1) : (ERROR_STATUS += 1)))"
+                if [ -n "${VERBOSE:-${VERBOSE_PROGRESS}}" ]; then
+                    _print_center "justify" "Status: ${SUCCESS_STATUS} Uploaded" " | ${ERROR_STATUS} Failed" "=" && _newline "\n"
+                else
+                    for _ in 1 2; do _clear_line 1; done
+                    _print_center "justify" "Status: ${SUCCESS_STATUS} Uploaded" " | ${ERROR_STATUS} Failed" "="
+                fi
+            done 4<< EOF
+$(printf "%s\n" "${files_upload_folder}")
+EOF
+            ;;
+        parallel)
+            NO_OF_PARALLEL_JOBS_FINAL="$((NO_OF_PARALLEL_JOBS > NO_OF_FILES ? NO_OF_FILES : NO_OF_PARALLEL_JOBS))"
+            [ -f "${TMPFILE}"SUCCESS ] && rm "${TMPFILE}"SUCCESS
+            [ -f "${TMPFILE}"ERROR ] && rm "${TMPFILE}"ERROR
+
+            # shellcheck disable=SC2016
+            (printf "%s\n" "${files_upload_folder}" | xargs -n1 -P"${NO_OF_PARALLEL_JOBS_FINAL}" -I {} sh -c '
+            eval "${SOURCE_UTILS}"
+            _upload_file_main "${PARSE_MODE}" "{}" "${ID}" true
+            ' 1>| "${TMPFILE}"SUCCESS 2>| "${TMPFILE}"ERROR) &
+            pid="${!}"
+
+            until [ -f "${TMPFILE}"SUCCESS ] || [ -f "${TMPFILE}"ERORR ]; do sleep 0.5; done
+            [ "${PARSE_MODE}" = parse ] && _clear_line 1
+            _newline "\n"
+
+            until ! kill -0 "${pid}" 2>| /dev/null 1>&2; do
+                SUCCESS_STATUS="$(($(wc -l < "${TMPFILE}"SUCCESS)))"
+                ERROR_STATUS="$(($(wc -l < "${TMPFILE}"ERROR)))"
+                sleep 1
+                [ "$((SUCCESS_STATUS + ERROR_STATUS))" != "${TOTAL}" ] &&
+                    _clear_line 1 && "${QUIET:-_print_center}" "justify" "Status" ": ${SUCCESS_STATUS} Uploaded | ${ERROR_STATUS} Failed" "="
+                TOTAL="$((SUCCESS_STATUS + ERROR_STATUS))"
+            done
+            SUCCESS_STATUS="$(($(wc -l < "${TMPFILE}"SUCCESS)))"
+            ERROR_STATUS="$(($(wc -l < "${TMPFILE}"ERROR)))"
+            ;;
+    esac
+    return 0
+}

--- a/sh/upload.sh
+++ b/sh/upload.sh
@@ -719,7 +719,7 @@ main() {
     [ $# = 0 ] && _short_help
 
     if [ -z "${SELF_SOURCE}" ]; then
-        UTILS_FOLDER="${UTILS_FOLDER:-${PWD}}" && SOURCE_UTILS=". '${UTILS_FOLDER}/common-utils.sh' && . '${UTILS_FOLDER}/drive-utils.sh'"
+        UTILS_FOLDER="${UTILS_FOLDER:-${PWD}}" && SOURCE_UTILS=". '${UTILS_FOLDER}/common-utils.sh' && . '${UTILS_FOLDER}/drive-utils.sh' && . '${UTILS_FOLDER}/upload-utils.sh'"
         eval "${SOURCE_UTILS}" || { printf "Error: Unable to source util files.\n" && exit 1; }
     else
         SOURCE_UTILS="SOURCED_GUPLOAD=true . \"$(cd "$(_dirname "${0}")" && pwd)/${0##*\/}\"" && eval "${SOURCE_UTILS}"

--- a/sh/upload.sh
+++ b/sh/upload.sh
@@ -130,6 +130,36 @@ _version_info() {
 }
 
 ###################################################
+# Function to cleanup config file
+# Remove invalid access tokens on the basis of corresponding expiry
+# Globals: None
+# Arguments: 1
+#   ${1} = config file
+# Result: read description
+###################################################
+_cleanup_config() {
+    config="${1:?Error: Missing config}" && unset values_regex _tmp
+
+    ! [ -f "${config}" ] && return 0
+
+    while read -r line <&4; do
+        expiry_value_name="${line%%=*}"
+        token_value_name="${expiry_value_name%%_EXPIRY}"
+
+        _tmp="${line##*=}" && _tmp="${_tmp%\"}" && expiry="${_tmp#\"}"
+        [ "${expiry}" -le "$(date +"%s")" ] &&
+            values_regex="${values_regex:+${values_regex}|}${expiry_value_name}=\".*\"|${token_value_name}=\".*\""
+    done 4<< EOF
+$(grep -F ACCESS_TOKEN_EXPIRY "${config}" || :)
+EOF
+
+    chmod +w "${config}" &&
+        printf "%s\n" "$(grep -Ev "^\$${values_regex:+|${values_regex}}" "${config}")" >| "${config}" &&
+        chmod -w "${config}"
+    return 0
+}
+
+###################################################
 # Process all arguments given to the script
 # Globals: 1 variable, 1 function
 #   Variable - HOME
@@ -764,7 +794,7 @@ main() {
                 printf "\n\n%s\n" "Script exited manually."
                 kill -9 -$$ &
             else
-                _auto_update &
+                { _cleanup_config "${CONFIG}" && _auto_update; } &
             fi
         } 2>| /dev/null 1>&2 || :
         return 0

--- a/sh/upload.sh
+++ b/sh/upload.sh
@@ -55,15 +55,12 @@ _short_help() {
 ###################################################
 _auto_update() {
     export REPO
-    (
-        _REPO="${REPO}"
-        command -v "${COMMAND_NAME}" 1> /dev/null &&
-            if [ -n "${_REPO:+${COMMAND_NAME:+${INSTALL_PATH:+${TYPE:+${TYPE_VALUE}}}}}" ]; then
-                current_time="$(date +'%s')"
-                [ "$((LAST_UPDATE_TIME + AUTO_UPDATE_INTERVAL))" -lt "$(date +'%s')" ] && _update
-                _update_value LAST_UPDATE_TIME "${current_time}"
-            fi
-    ) 2>| /dev/null 1>&2 &
+    command -v "${COMMAND_NAME}" 1> /dev/null &&
+        if [ -n "${REPO:+${COMMAND_NAME:+${INSTALL_PATH:+${TYPE:+${TYPE_VALUE}}}}}" ]; then
+            current_time="$(date +'%s')"
+            [ "$((LAST_UPDATE_TIME + AUTO_UPDATE_INTERVAL))" -lt "$(date +'%s')" ] && _update
+            _update_value LAST_UPDATE_TIME "${current_time}"
+        fi
     return 0
 }
 
@@ -738,26 +735,28 @@ main() {
             [ -n "${SUPPORT_ANSI_ESCAPES}" ] && printf "\033[?25h"
 
             # update the config with latest ACCESS_TOKEN and ACCESS_TOKEN_EXPIRY only if changed
-            NEW_ACCESS_TOKEN="$(. "${TMPFILE}_ACCESS_TOKEN" && printf "%s\n" "${ACCESS_TOKEN}")"
-            [ "${INITIAL_ACCESS_TOKEN}" = "${NEW_ACCESS_TOKEN}" ] || {
-                _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-                _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+            [ -f "${TMPFILE}_ACCESS_TOKEN" ] && {
+                . "${TMPFILE}_ACCESS_TOKEN"
+                [ "${INITIAL_ACCESS_TOKEN}" = "${ACCESS_TOKEN}" ] || {
+                    _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
+                    _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                }
             }
 
             # grab all chidren processes of access token service
             # https://askubuntu.com/a/512872
-            token_service_pids="$(ps --ppid="${ACCESS_TOKEN_SERVICE_PID}" -o pid=)"
-            # first kill parent id, then children processes
-            kill "${ACCESS_TOKEN_SERVICE_PID}"
-            for pid in ${token_service_pids}; do
-                kill "${pid}"
-            done
+            [ -n "${ACCESS_TOKEN_SERVICE_PID}" ] && {
+                token_service_pids="$(ps --ppid="${ACCESS_TOKEN_SERVICE_PID}" -o pid=)"
+                # first kill parent id, then children processes
+                kill "${ACCESS_TOKEN_SERVICE_PID}"
+            }
 
-            # manually kill all script children pids
+            # grab all script children pids
             script_children_pids="$(ps --ppid="${MAIN_PID}" -o pid=)"
-            for pid in ${script_children_pids}; do
-                kill "${pid}"
-            done
+
+            # kill all grabbed children processes
+            # shellcheck disable=SC2086
+            kill ${token_service_pids} ${script_children_pids}
 
             rm -f "${TMPFILE:?}"*
 
@@ -765,9 +764,9 @@ main() {
                 printf "\n\n%s\n" "Script exited manually."
                 kill -9 -$$ &
             else
-                _auto_update
+                _auto_update &
             fi
-        } 2>| /dev/null || :
+        } 2>| /dev/null 1>&2 || :
         return 0
     }
 


### PR DESCRIPTION

    gupload: Add _cleanup_config function
    
    this function removes any expired tokens on the basis of expiry
    
    will be useful once service accounts or multi account config implemented


    gupload: Improve _cleanup and _auto_update function
    
    check tmp access token file before comparing access token
    
    fix access token in config file if was update when script was running
    
    don't create a extra subshell for auto update


    Move upload functions to new file [ upload-utils ] | Misc
    
    * Arrange functions alphabatically
    
    *  Move _extract_id from common to drive utils
    
    * _collect_file_info: directly create info var
    
    drive-utils: Functions related to google drive only
    
    upload-utils: All Functions related to uploading a file ( excluding drive api functions ), pre and post upload functions
    
    common-utils: Functions which cannot be added either in drive or upload utils


    common-utils.bash: Don't log _url_decode trace when -D flag is used
    
    for no reason, it just fills up the logs


    README: Update credentials generation info
