### PR TITLE
Resolve #161, #162 | Misc

### DIFF
--- a/bash/release/gupload
+++ b/bash/release/gupload
@@ -932,25 +932,36 @@ export -f "${ALL_FUNCTIONS[@]}"
 # Globals: 3 variables, 2 functions
 #   Variables - API_URL, API_VERSION, ACCESS_TOKEN
 #   Functions - _url_encode, _json_value
-# Arguments: 2
+# Arguments: 4
 #   ${1} = file name
 #   ${2} = root dir id of file
-# Result: print file id else blank
+#   ${3} = mode ( size or md5Checksum or empty )
+#   ${4} = if mode = empty, then not required
+#             mode = size, then size
+#             mode = md5Checksum, then md5sum
+# Result: print search response if id fetched
+#         check size and md5sum if mode size or md5Checksum
 # Reference:
 #   https://developers.google.com/drive/api/v3/search-files
 ###################################################
 _check_existing_file() {
     [[ $# -lt 2 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
-    declare name="${1##*/}" rootdir="${2}" query search_response id
+    declare name="${1}" rootdir="${2}" mode="${3}" param_value="${4}" query search_response id
 
     "${EXTRA_LOG}" "justify" "Checking if file" " exists on gdrive.." "-" 1>&2
     query="$(_url_encode "name=\"${name}\" and '${rootdir}' in parents and trashed=false")"
 
     search_response="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-        "${API_URL}/drive/${API_VERSION}/files?q=${query}&fields=files(id,name,mimeType)&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
+        "${API_URL}/drive/${API_VERSION}/files?q=${query}&fields=files(id,name,mimeType${mode:+,${mode}})&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
     _clear_line 1 1>&2
 
-    { _json_value id 1 1 <<< "${search_response}" 2>| /dev/null 1>&2 && printf "%s\n" "${search_response}"; } || return 1
+    _json_value id 1 1 <<< "${search_response}" 2>| /dev/null 1>&2 || return 1
+
+    [[ -n ${mode} ]] && {
+        [[ "$(_json_value "${mode}" 1 1 <<< "${search_response}")" = "${param_value}" ]] || return 1
+    }
+
+    printf "%s\n" "${search_response}"
     return 0
 }
 
@@ -965,6 +976,7 @@ _check_existing_file() {
 #   ${3} = root dir id for file
 #   ${4} = name of file
 #   ${5} = size of file
+#   ${6} = md5sum of file
 # Result: On
 #   Success - Upload/Update file and export FILE_ID
 #   Error - return 1
@@ -973,7 +985,7 @@ _check_existing_file() {
 ###################################################
 _clone_file() {
     [[ $# -lt 5 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
-    declare job="${1}" file_id="${2}" file_root_id="${3}" name="${4}" size="${5}"
+    declare job="${1}" file_id="${2}" file_root_id="${3}" name="${4}" size="${5}" md5="${6}"
     declare clone_file_post_data clone_file_response readable_size _file_id description escaped_name && STRING="Cloned"
     escaped_name="$(_json_escape j "${name}")" print_name="$(_json_escape p "${name}")" readable_size="$(_bytes_to_human "${size}")"
 
@@ -988,7 +1000,11 @@ _clone_file() {
     _print_center "justify" "${print_name} " "| ${readable_size}" "="
 
     if [[ ${job} = update ]]; then
-        declare file_check_json
+        declare file_check_json check_value_type check_value
+        case "${CHECK_MODE}" in
+            2) check_value_type="size" check_value="${size}" ;;
+            3) check_value_type="md5Checksum" check_value="${md5}" ;;
+        esac
         # Check if file actually exists.
         if file_check_json="$(_check_existing_file "${escaped_name}" "${file_root_id}")"; then
             if [[ -n ${SKIP_DUPLICATES} ]]; then
@@ -1117,7 +1133,7 @@ _extract_id() {
 # Interrupted uploads can be resumed.
 # Globals: 8 variables, 11 functions
 #   Variables - API_URL, API_VERSION, QUIET, VERBOSE, VERBOSE_PROGRESS, CURL_PROGRESS, LOG_FILE_ID, ACCESS_TOKEN, DESCRIPTION_FILE
-#   Functions - _url_encode, _json_value, _json_escape _print_center, _bytes_to_human
+#   Functions - _url_encode, _json_value, _json_escape _print_center, _bytes_to_human, _check_existing_file
 #               _generate_upload_link, _upload_file_from_uri, _log_upload_session, _remove_upload_session
 #               _full_upload, _collect_file_info
 # Arguments: 3
@@ -1162,9 +1178,20 @@ _upload_file() {
 
     # Set proper variables for overwriting files
     [[ ${job} = update ]] && {
-        declare file_check_json
+        declare file_check_json check_value
+        case "${CHECK_MODE}" in
+            2) check_value_type="size" check_value="${inputsize}" ;;
+            3)
+                check_value_type="md5Checksum"
+                check_value="$(md5sum "${input}")" || {
+                    "${QUIET:-_print_center}" "justify" "Error: cannot calculate md5sum of given file." "=" 1>&2
+                    return 1
+                }
+                check_value="${check_value%% *}"
+                ;;
+        esac
         # Check if file actually exists, and create if not.
-        if file_check_json="$(_check_existing_file "${escaped_slug}" "${folder_id}")"; then
+        if file_check_json="$(_check_existing_file "${escaped_slug}" "${folder_id}" "${check_value_type}" "${check_value}")"; then
             if [[ -n ${SKIP_DUPLICATES} ]]; then
                 # Stop upload if already exists ( -d/--skip-duplicates )
                 _collect_file_info "${file_check_json}" "${escaped_slug}" || return 1
@@ -1552,11 +1579,12 @@ Options:\n
   -f | --[file|folder] - Specify files and folders explicitly in one command, use multiple times for multiple folder/files. See README for more use of this command.\n
   -cl | --clone - Upload a gdrive file without downloading, require accessible gdrive link or id as argument.\n
   -o | --overwrite - Overwrite the files with the same name, if present in the root folder/input folder, also works with recursive folders.\n
+  -d | --skip-duplicates - Do not upload the files with the same name and size, if already present in the root folder/input folder, also works with recursive folders.\n
+  -cm | --check-mode - Additional flag for --overwrite and --skip-duplicates flag. Can be used to change check mode in those flags, available args are 'size' and 'md5'.\n
   -desc | --description | --description-all - Specify description for the given file. To use the respective metadata of a file, below is the format:\n
          File name ( fullname ): %f | Size: %s | Mime Type: %m\n
          Now to actually use it: --description 'Filename: %f, Size: %s, Mime: %m'\n
          Note: For files inside folders, use --description-all flag.\n
-  -d | --skip-duplicates - Do not upload the files with the same name, if already present in the root folder/input folder, also works with recursive folders.\n
   -S | --share <optional_email_address>- Share the uploaded input file/folder, grant reader permission to provided email address or to everyone with the shareable link.\n
   -SM | -sm | --share-mode 'share mode' - Specify the share mode for sharing file.\n
         Share modes are: r / reader - Read only permission.\n
@@ -1655,7 +1683,7 @@ _setup_arguments() {
     # De-initialize if any variables set already.
     unset LIST_ACCOUNTS UPDATE_DEFAULT_ACCOUNT CUSTOM_ACCOUNT_NAME NEW_ACCOUNT_NAME DELETE_ACCOUNT_NAME ACCOUNT_ONLY_RUN
     unset FOLDERNAME LOCAL_INPUT_ARRAY ID_INPUT_ARRAY CONTINUE_WITH_NO_INPUT
-    unset PARALLEL NO_OF_PARALLEL_JOBS SHARE SHARE_ROLE SHARE_EMAIL OVERWRITE SKIP_DUPLICATES DESCRIPTION SKIP_SUBDIRS ROOTDIR QUIET
+    unset PARALLEL NO_OF_PARALLEL_JOBS SHARE SHARE_ROLE SHARE_EMAIL OVERWRITE SKIP_DUPLICATES CHECK_MODE DESCRIPTION SKIP_SUBDIRS ROOTDIR QUIET
     unset VERBOSE VERBOSE_PROGRESS DEBUG LOG_FILE_ID CURL_SPEED RETRY
     export CURL_PROGRESS="-s" EXTRA_LOG=":" CURL_PROGRESS_EXTRA="-s"
     INFO_PATH="${HOME}/.google-drive-upload" CONFIG_INFO="${INFO_PATH}/google-drive-upload.configpath"
@@ -1738,6 +1766,14 @@ _setup_arguments() {
                 ;;
             -o | --overwrite) export OVERWRITE="Overwrite" UPLOAD_MODE="update" ;;
             -d | --skip-duplicates) export SKIP_DUPLICATES="Skip Existing" UPLOAD_MODE="update" ;;
+            -cm | --check-mode)
+                _check_longoptions "${1}" "${2}"
+                case "${2}" in
+                    size) export CHECK_MODE="2" && shift ;;
+                    md5) export CHECK_MODE="3" && shift ;;
+                    *) printf "\nError: -cm/--check-mode takes size and md5 as argument.\n" ;;
+                esac
+                ;;
             -desc | --description | --description-all)
                 _check_longoptions "${1}" "${2}"
                 [[ ${1} = "--description-all" ]] && export DESCRIPTION_ALL="true"
@@ -1864,6 +1900,15 @@ _setup_arguments() {
         [[ -n ${DELETE_ACCOUNT_NAME:-${LIST_ACCOUNTS:-}} ]] && exit 0
         # don't exit right away when new account is created but also let the rootdir stuff execute
         [[ -n ${NEW_ACCOUNT_NAME} ]] && CONTINUE_WITH_NO_INPUT="true"
+    }
+
+    # set CHECK_MODE if empty, below are check mode values
+    # 1 = check only name, 2 = check name and size, 3 = check name and md5sum
+    [[ -z ${CHECK_MODE} ]] && {
+        case "${SKIP_DUPLICATES:-${OVERWRITE}}" in
+            "Overwrite") export CHECK_MODE="1" ;;
+            "Skip Existing") export CHECK_MODE="2" ;;
+        esac
     }
 
     return 0
@@ -2110,11 +2155,13 @@ _process_arguments() {
         { [[ ${Aseen[${gdrive_id}]} ]] && continue; } || Aseen[${gdrive_id}]=x
         _print_center "justify" "Given Input" ": ID" "="
         "${EXTRA_LOG}" "justify" "Checking if id exists.." "-"
-        json="$(_drive_info "${gdrive_id}" "name,mimeType,size" || :)"
+        [[ ${CHECK_MODE} = "md5Checksum" ]] && declare param="md5Checksum"
+        json="$(_drive_info "${gdrive_id}" "name,mimeType,size${param:+,${param}}" || :)"
         if ! _json_value code 1 1 <<< "${json}" 2>| /dev/null 1>&2; then
             type="$(_json_value mimeType 1 1 <<< "${json}" || :)"
             name="$(_json_value name 1 1 <<< "${json}" || :)"
             size="$(_json_value size 1 1 <<< "${json}" || :)"
+            [[ ${CHECK_MODE} = "md5Checksum" ]] && md5="$(_json_value md5Checksum 1 1 <<< "${json}" || :)"
             for _ in 1 2; do _clear_line 1; done
             if [[ ${type} =~ folder ]]; then
                 # export DESCRIPTION_FILE only if DESCRIPTION_ALL var is available, used for descriptions in _clone_file function
@@ -2128,7 +2175,7 @@ _process_arguments() {
 
                 _print_center "justify" "Given Input" ": File ID" "="
                 _print_center "justify" "Upload Method" ": ${SKIP_DUPLICATES:-${OVERWRITE:-Create}}" "=" && _newline "\n"
-                _clone_file "${UPLOAD_MODE:-create}" "${gdrive_id}" "${WORKSPACE_FOLDER_ID}" "${name}" "${size}" ||
+                _clone_file "${UPLOAD_MODE:-create}" "${gdrive_id}" "${WORKSPACE_FOLDER_ID}" "${name}" "${size}" "${md5}" ||
                     { for _ in 1 2; do _clear_line 1; done && continue; }
             fi
             _share_and_print_link "${FILE_ID}"

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ _check_debug() {
         if [ -z "${QUIET}" ]; then
             # check if running in terminal and support ansi escape sequences
             case "${TERM}" in
-                xterm* | rxvt* | urxvt* | linux* | vt* | screen*) ansi_escapes="true" ;;
+                xterm* | rxvt* | urxvt* | linux* | vt* | screen* | st*) ansi_escapes="true" ;;
             esac
             if [ -t 2 ] && [ -n "${ansi_escapes}" ]; then
                 ! COLUMNS="$(_get_columns_size)" || [ "${COLUMNS:-0}" -lt 45 ] 2>| /dev/null &&

--- a/sh/common-utils.sh
+++ b/sh/common-utils.sh
@@ -183,19 +183,17 @@ _json_escape() {
     # just for refrence "s|'|\'|g"
     if [ "${mode_json_escape}" = "j" ]; then
         output_json_escape="$(printf "%s" "${input_json_escape}" | sed \
-            -e "s|'\'|'\\'|g" \
-            -e "s|'/'|'\/'|g" \
+            -e "s|\\\|\\\\\\\|g" \
+            -e "s|\/|\\\/|g" \
             -e 's/\"/\\\"/g' \
-            -e ':a; $!N' \
-            -e 's|\t|\\t|g' \
-            -e 's|\r|\\r|g' \
-            -e 's|\f|\\f|g')"
+            -e "s/$(printf '\t')/\\t/g" \
+            -e "s/$(printf '\r')/\\r/g" \
+            -e "s/$(printf '\f')/\\f/g")"
     else
         output_json_escape="$(printf "%s" "${input_json_escape}" | sed \
-            -e ':a; $!N' \
-            -e 's|\t|\\t|g' \
-            -e 's|\r|\\r|g' \
-            -e 's|\f|\\f|g')"
+            -e "s/$(printf '\t')/\\t/g" \
+            -e "s/$(printf '\r')/\\r/g" \
+            -e "s/$(printf '\f')/\\f/g")"
     fi
     # use awk because sed just messes up with newlines
     output_json_escape="$(printf "%s" "${output_json_escape}" | awk '{printf "%s%s",sep,$0; sep="\\n"} END{print ""}')"

--- a/sh/release/gsync
+++ b/sh/release/gsync
@@ -184,19 +184,17 @@ _json_escape() {
     # just for refrence "s|'|\'|g"
     if [ "${mode_json_escape}" = "j" ]; then
         output_json_escape="$(printf "%s" "${input_json_escape}" | sed \
-            -e "s|'\'|'\\'|g" \
-            -e "s|'/'|'\/'|g" \
+            -e "s|\\\|\\\\\\\|g" \
+            -e "s|\/|\\\/|g" \
             -e 's/\"/\\\"/g' \
-            -e ':a; $!N' \
-            -e 's|\t|\\t|g' \
-            -e 's|\r|\\r|g' \
-            -e 's|\f|\\f|g')"
+            -e "s/$(printf '\t')/\\t/g" \
+            -e "s/$(printf '\r')/\\r/g" \
+            -e "s/$(printf '\f')/\\f/g")"
     else
         output_json_escape="$(printf "%s" "${input_json_escape}" | sed \
-            -e ':a; $!N' \
-            -e 's|\t|\\t|g' \
-            -e 's|\r|\\r|g' \
-            -e 's|\f|\\f|g')"
+            -e "s/$(printf '\t')/\\t/g" \
+            -e "s/$(printf '\r')/\\r/g" \
+            -e "s/$(printf '\f')/\\f/g")"
     fi
     # use awk because sed just messes up with newlines
     output_json_escape="$(printf "%s" "${output_json_escape}" | awk '{printf "%s%s",sep,$0; sep="\\n"} END{print ""}')"

--- a/sh/release/gupload
+++ b/sh/release/gupload
@@ -880,26 +880,37 @@ _token_bg_service() {
 # Globals: 3 variables, 2 functions
 #   Variables - API_URL, API_VERSION, ACCESS_TOKEN
 #   Functions - _url_encode, _json_value
-# Arguments: 2
+# Arguments: 4
 #   ${1} = file name
 #   ${2} = root dir id of file
-# Result: print file id else blank
+#   ${3} = mode ( size or md5Checksum or empty )
+#   ${4} = if mode = empty, then not required
+#             mode = size, then size
+#             mode = md5Checksum, then md5sum
+# Result: print search response if id fetched
+#         check size and md5sum if mode size or md5Checksum
 # Reference:
 #   https://developers.google.com/drive/api/v3/search-files
 ###################################################
 _check_existing_file() (
     [ $# -lt 2 ] && printf "Missing arguments\n" && return 1
-    name_check_existing_file="${1##*/}" rootdir_check_existing_file="${2}"
+    name_check_existing_file="${1}" rootdir_check_existing_file="${2}" mode_check_existing_file="${3}" param_value_check_existing_file="${4}"
     unset query_check_existing_file response_check_existing_file id_check_existing_file
 
     "${EXTRA_LOG}" "justify" "Checking if file" " exists on gdrive.." "-" 1>&2
     query_check_existing_file="$(_url_encode "name=\"${name_check_existing_file}\" and '${rootdir_check_existing_file}' in parents and trashed=false and 'me' in writers")"
 
     response_check_existing_file="$(_api_request "${CURL_PROGRESS_EXTRA}" \
-        "${API_URL}/drive/${API_VERSION}/files?q=${query_check_existing_file}&fields=files(id,name,mimeType)&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
+        "${API_URL}/drive/${API_VERSION}/files?q=${query_check_existing_file}&fields=files(id,name,mimeType${mode_check_existing_file:+,${mode_check_existing_file}})&supportsAllDrives=true&includeItemsFromAllDrives=true" || :)" && _clear_line 1 1>&2
     _clear_line 1 1>&2
 
-    { printf "%s\n" "${response_check_existing_file}" | _json_value id 1 1 2>| /dev/null 1>&2 && printf "%s\n" "${response_check_existing_file}"; } || return 1
+    printf "%s\n" "${response_check_existing_file}" | _json_value id 1 1 2>| /dev/null 1>&2 || return 1
+
+    [ -n "${mode_check_existing_file}" ] && {
+        [ "$(printf "%s\n" "${response_check_existing_file}" | _json_value "${mode_check_existing_file}" 1 1)" = "${param_value_check_existing_file}" ] || return 1
+    }
+
+    printf "%s\n" "${response_check_existing_file}"
     return 0
 )
 
@@ -914,6 +925,7 @@ _check_existing_file() (
 #   ${3} = root dir id for file
 #   ${4} = name of file
 #   ${5} = size of file
+#   ${6} = md5sum of file
 # Result: On
 #   Success - Upload/Update file and export FILE_ID
 #   Error - return 1
@@ -922,7 +934,7 @@ _check_existing_file() (
 ###################################################
 _clone_file() {
     [ $# -lt 5 ] && printf "Missing arguments\n" && return 1
-    job_clone_file="${1}" file_id_clone_file="${2}" file_root_id_clone_file="${3}" name_clone_file="${4}" size_clone_file="${5}"
+    job_clone_file="${1}" file_id_clone_file="${2}" file_root_id_clone_file="${3}" name_clone_file="${4}" size_clone_file="${5}" md5_clone_file="${6}"
     unset post_data_clone_file response_clone_file readable_size_clone_file description_clone_file && STRING="Cloned"
     readable_size_clone_file="$(printf "%s\n" "${size_clone_file}" | _bytes_to_human)"
     escaped_name_clone_file="$(_json_escape j "${name_clone_file}")" print_name_clone_file="$(_json_escape p "${name_clone_file}")"
@@ -938,9 +950,13 @@ _clone_file() {
     _print_center "justify" "${print_name_clone_file} " "| ${readable_size_clone_file}" "="
 
     if [ "${job_clone_file}" = update ]; then
-        unset file_check_json_clone_file
+        unset file_check_json_clone_file check_value_type_clone_file check_value_clone_file
+        case "${CHECK_MODE}" in
+            2) check_value_type_clone_file="size" check_value_clone_file="${size_clone_file}" ;;
+            3) check_value_type_clone_file="md5Checksum" check_value_clone_file="${md5_clone_file}" ;;
+        esac
         # Check if file actually exists.
-        if file_check_json_clone_file="$(_check_existing_file "${escaped_name_clone_file}" "${file_root_id_clone_file}")"; then
+        if file_check_json_clone_file="$(_check_existing_file "${escaped_name_clone_file}" "${file_root_id_clone_file}" "${check_value_type_clone_file}" "${check_value_clone_file}")"; then
             if [ -n "${SKIP_DUPLICATES}" ]; then
                 _collect_file_info "${file_check_json_clone_file}" "${print_name_clone_file}" || return 1
                 _clear_line 1
@@ -1070,7 +1086,7 @@ _extract_id() {
 # Interrupted uploads can be resumed.
 # Globals: 8 variables, 11 functions
 #   Variables - API_URL, API_VERSION, QUIET, VERBOSE, VERBOSE_PROGRESS, CURL_PROGRESS, LOG_FILE_ID, ACCESS_TOKEN, DESCRIPTION_FILE
-#   Functions - _url_encode, _json_value, _json_escape, _print_center, _bytes_to_human
+#   Functions - _url_encode, _json_value, _json_escape, _print_center, _bytes_to_human, _check_existing_file
 #               _generate_upload_link, _upload_file_from_uri, _log_upload_session, _remove_upload_session
 #               _full_upload, _collect_file_info
 # Arguments: 3
@@ -1117,9 +1133,20 @@ _upload_file() {
 
     # Set proper variables for overwriting files
     [ "${job_upload_file}" = update ] && {
-        unset file_check_json_upload_file
+        unset file_check_json_upload_file check_value_upload_file
+        case "${CHECK_MODE}" in
+            2) check_value_type_upload_file="size" check_value_upload_file="${inputsize_upload_file}" ;;
+            3)
+                check_value_type_upload_file="md5Checksum"
+                check_value_upload_file="$(md5sum "${input_upload_file}")" || {
+                    "${QUIET:-_print_center}" "justify" "Error: cannot calculate md5sum of given file." "=" 1>&2
+                    return 1
+                }
+                check_value_upload_file="${check_value_upload_file%% *}"
+                ;;
+        esac
         # Check if file actually exists, and create if not.
-        if file_check_json_upload_file="$(_check_existing_file "${escaped_slug_upload_file}" "${folder_id_upload_file}")"; then
+        if file_check_json_upload_file="$(_check_existing_file "${escaped_slug_upload_file}" "${folder_id_upload_file}" "${check_value_type_upload_file}" "${check_value_upload_file}")"; then
             if [ -n "${SKIP_DUPLICATES}" ]; then
                 # Stop upload if already exists ( -d/--skip-duplicates )
                 _collect_file_info "${file_check_json_upload_file}" "${print_slug_upload_file}" || return 1
@@ -1488,11 +1515,12 @@ Options:\n
   -f | --[file|folder] - Specify files and folders explicitly in one command, use multiple times for multiple folder/files. See README for more use of this command.\n
   -cl | --clone - Upload a gdrive file without downloading, require accessible gdrive link or id as argument.\n
   -o | --overwrite - Overwrite the files with the same name, if present in the root folder/input folder, also works with recursive folders.\n
+  -d | --skip-duplicates - Do not upload the files with the same name and size, if already present in the root folder/input folder, also works with recursive folders.\n
+  -cm | --check-mode - Additional flag for --overwrite and --skip-duplicates flag. Can be used to change check mode in those flags, available args are 'size' and 'md5'.\n
   -desc | --description | --description-all - Specify description for the given file. To use the respective metadata of a file, below is the format:\n
          File name ( fullname ): %f | Size: %s | Mime Type: %m\n
          Now to actually use it: --description 'Filename: %f, Size: %s, Mime: %m'\n
          Note: For files inside folders, use --description-all flag.\n
-  -d | --skip-duplicates - Do not upload the files with the same name, if already present in the root folder/input folder, also works with recursive folders.\n
   -S | --share <optional_email_address>- Share the uploaded input file/folder, grant reader permission to provided email address or to everyone with the shareable link.\n
   -SM | -sm | --share-mode 'share mode' - Specify the share mode for sharing file.\n
         Share modes are: r / reader - Read only permission.\n
@@ -1593,7 +1621,7 @@ _setup_arguments() {
     # De-initialize if any variables set already.
     unset LIST_ACCOUNTS UPDATE_DEFAULT_ACCOUNT CUSTOM_ACCOUNT_NAME NEW_ACCOUNT_NAME DELETE_ACCOUNT_NAME ACCOUNT_ONLY_RUN
     unset FOLDERNAME FINAL_LOCAL_INPUT_ARRAY FINAL_ID_INPUT_ARRAY CONTINUE_WITH_NO_INPUT
-    unset PARALLEL NO_OF_PARALLEL_JOBS SHARE SHARE_EMAIL SHARE_ROLE OVERWRITE SKIP_DUPLICATES SKIP_SUBDIRS DESCRIPTION ROOTDIR QUIET
+    unset PARALLEL NO_OF_PARALLEL_JOBS SHARE SHARE_EMAIL SHARE_ROLE OVERWRITE SKIP_DUPLICATES CHECK_MODE SKIP_SUBDIRS DESCRIPTION ROOTDIR QUIET
     unset VERBOSE VERBOSE_PROGRESS DEBUG LOG_FILE_ID CURL_SPEED RETRY
     export CURL_PROGRESS="-s" EXTRA_LOG=":" CURL_PROGRESS_EXTRA="-s"
     INFO_PATH="${HOME}/.google-drive-upload" CONFIG_INFO="${INFO_PATH}/google-drive-upload.configpath"
@@ -1676,6 +1704,14 @@ _setup_arguments() {
                 ;;
             -o | --overwrite) export OVERWRITE="Overwrite" UPLOAD_MODE="update" ;;
             -d | --skip-duplicates) export SKIP_DUPLICATES="Skip Existing" UPLOAD_MODE="update" ;;
+            -cm | --check-mode)
+                _check_longoptions "${1}" "${2}"
+                case "${2}" in
+                    size) export CHECK_MODE="2" && shift ;;
+                    md5) export CHECK_MODE="3" && shift ;;
+                    *) printf "\nError: -cm/--check-mode takes size and md5 as argument.\n" ;;
+                esac
+                ;;
             -desc | --description | --description-all)
                 _check_longoptions "${1}" "${2}"
                 [ "${1}" = "--description-all" ] && export DESCRIPTION_ALL="true"
@@ -1813,6 +1849,15 @@ _setup_arguments() {
         [ -n "${DELETE_ACCOUNT_NAME:-${LIST_ACCOUNTS:-}}" ] && exit 0
         # don't exit right away when new account is created but also let the rootdir stuff execute
         [ -n "${NEW_ACCOUNT_NAME}" ] && CONTINUE_WITH_NO_INPUT="true"
+    }
+
+    # set CHECK_MODE if empty, below are check mode values
+    # 1 = check only name, 2 = check name and size, 3 = check name and md5sum
+    [ -z "${CHECK_MODE}" ] && {
+        case "${SKIP_DUPLICATES:-${OVERWRITE}}" in
+            "Overwrite") export CHECK_MODE="1" ;;
+            "Skip Existing") export CHECK_MODE="2" ;;
+        esac
     }
 
     return 0
@@ -2072,11 +2117,13 @@ EOF
         esac; do
         _print_center "justify" "Given Input" ": ID" "="
         "${EXTRA_LOG}" "justify" "Checking if id exists.." "-"
-        json="$(_drive_info "${gdrive_id}" "name,mimeType,size")" || :
+        [ "${CHECK_MODE}" = "md5Checksum" ] && param="md5Checksum"
+        json="$(_drive_info "${gdrive_id}" "name,mimeType,size${param:+,${param}}")" || :
         if ! printf "%s\n" "${json}" | _json_value code 1 1 2>| /dev/null 1>&2; then
             type="$(printf "%s\n" "${json}" | _json_value mimeType 1 1 || :)"
             name="$(printf "%s\n" "${json}" | _json_value name 1 1 || :)"
             size="$(printf "%s\n" "${json}" | _json_value size 1 1 || :)"
+            [ "${CHECK_MODE}" = "md5Checksum" ] && md5="$(printf "%s\n" "${json}" | _json_value md5Checksum 1 1 || :)"
             for _ in 1 2; do _clear_line 1; done
             case "${type}" in
                 *folder*)
@@ -2092,7 +2139,7 @@ EOF
 
                     _print_center "justify" "Given Input" ": File ID" "="
                     _print_center "justify" "Upload Method" ": ${SKIP_DUPLICATES:-${OVERWRITE:-Create}}" "=" && _newline "\n"
-                    _clone_file "${UPLOAD_MODE:-create}" "${gdrive_id}" "${WORKSPACE_FOLDER_ID}" "${name}" "${size}" ||
+                    _clone_file "${UPLOAD_MODE:-create}" "${gdrive_id}" "${WORKSPACE_FOLDER_ID}" "${name}" "${size}" "${md5}" ||
                         { for _ in 1 2; do _clear_line 1; done && continue; }
                     ;;
             esac

--- a/sh/release/gupload
+++ b/sh/release/gupload
@@ -184,19 +184,17 @@ _json_escape() {
     # just for refrence "s|'|\'|g"
     if [ "${mode_json_escape}" = "j" ]; then
         output_json_escape="$(printf "%s" "${input_json_escape}" | sed \
-            -e "s|'\'|'\\'|g" \
-            -e "s|'/'|'\/'|g" \
+            -e "s|\\\|\\\\\\\|g" \
+            -e "s|\/|\\\/|g" \
             -e 's/\"/\\\"/g' \
-            -e ':a; $!N' \
-            -e 's|\t|\\t|g' \
-            -e 's|\r|\\r|g' \
-            -e 's|\f|\\f|g')"
+            -e "s/$(printf '\t')/\\t/g" \
+            -e "s/$(printf '\r')/\\r/g" \
+            -e "s/$(printf '\f')/\\f/g")"
     else
         output_json_escape="$(printf "%s" "${input_json_escape}" | sed \
-            -e ':a; $!N' \
-            -e 's|\t|\\t|g' \
-            -e 's|\r|\\r|g' \
-            -e 's|\f|\\f|g')"
+            -e "s/$(printf '\t')/\\t/g" \
+            -e "s/$(printf '\r')/\\r/g" \
+            -e "s/$(printf '\f')/\\f/g")"
     fi
     # use awk because sed just messes up with newlines
     output_json_escape="$(printf "%s" "${output_json_escape}" | awk '{printf "%s%s",sep,$0; sep="\\n"} END{print ""}')"

--- a/sh/upload.sh
+++ b/sh/upload.sh
@@ -22,11 +22,12 @@ Options:\n
   -f | --[file|folder] - Specify files and folders explicitly in one command, use multiple times for multiple folder/files. See README for more use of this command.\n
   -cl | --clone - Upload a gdrive file without downloading, require accessible gdrive link or id as argument.\n
   -o | --overwrite - Overwrite the files with the same name, if present in the root folder/input folder, also works with recursive folders.\n
+  -d | --skip-duplicates - Do not upload the files with the same name and size, if already present in the root folder/input folder, also works with recursive folders.\n
+  -cm | --check-mode - Additional flag for --overwrite and --skip-duplicates flag. Can be used to change check mode in those flags, available args are 'size' and 'md5'.\n
   -desc | --description | --description-all - Specify description for the given file. To use the respective metadata of a file, below is the format:\n
          File name ( fullname ): %f | Size: %s | Mime Type: %m\n
          Now to actually use it: --description 'Filename: %f, Size: %s, Mime: %m'\n
          Note: For files inside folders, use --description-all flag.\n
-  -d | --skip-duplicates - Do not upload the files with the same name, if already present in the root folder/input folder, also works with recursive folders.\n
   -S | --share <optional_email_address>- Share the uploaded input file/folder, grant reader permission to provided email address or to everyone with the shareable link.\n
   -SM | -sm | --share-mode 'share mode' - Specify the share mode for sharing file.\n
         Share modes are: r / reader - Read only permission.\n
@@ -127,7 +128,7 @@ _setup_arguments() {
     # De-initialize if any variables set already.
     unset LIST_ACCOUNTS UPDATE_DEFAULT_ACCOUNT CUSTOM_ACCOUNT_NAME NEW_ACCOUNT_NAME DELETE_ACCOUNT_NAME ACCOUNT_ONLY_RUN
     unset FOLDERNAME FINAL_LOCAL_INPUT_ARRAY FINAL_ID_INPUT_ARRAY CONTINUE_WITH_NO_INPUT
-    unset PARALLEL NO_OF_PARALLEL_JOBS SHARE SHARE_EMAIL SHARE_ROLE OVERWRITE SKIP_DUPLICATES SKIP_SUBDIRS DESCRIPTION ROOTDIR QUIET
+    unset PARALLEL NO_OF_PARALLEL_JOBS SHARE SHARE_EMAIL SHARE_ROLE OVERWRITE SKIP_DUPLICATES CHECK_MODE SKIP_SUBDIRS DESCRIPTION ROOTDIR QUIET
     unset VERBOSE VERBOSE_PROGRESS DEBUG LOG_FILE_ID CURL_SPEED RETRY
     export CURL_PROGRESS="-s" EXTRA_LOG=":" CURL_PROGRESS_EXTRA="-s"
     INFO_PATH="${HOME}/.google-drive-upload" CONFIG_INFO="${INFO_PATH}/google-drive-upload.configpath"
@@ -210,6 +211,14 @@ _setup_arguments() {
                 ;;
             -o | --overwrite) export OVERWRITE="Overwrite" UPLOAD_MODE="update" ;;
             -d | --skip-duplicates) export SKIP_DUPLICATES="Skip Existing" UPLOAD_MODE="update" ;;
+            -cm | --check-mode)
+                _check_longoptions "${1}" "${2}"
+                case "${2}" in
+                    size) export CHECK_MODE="2" && shift ;;
+                    md5) export CHECK_MODE="3" && shift ;;
+                    *) printf "\nError: -cm/--check-mode takes size and md5 as argument.\n" ;;
+                esac
+                ;;
             -desc | --description | --description-all)
                 _check_longoptions "${1}" "${2}"
                 [ "${1}" = "--description-all" ] && export DESCRIPTION_ALL="true"
@@ -347,6 +356,15 @@ _setup_arguments() {
         [ -n "${DELETE_ACCOUNT_NAME:-${LIST_ACCOUNTS:-}}" ] && exit 0
         # don't exit right away when new account is created but also let the rootdir stuff execute
         [ -n "${NEW_ACCOUNT_NAME}" ] && CONTINUE_WITH_NO_INPUT="true"
+    }
+
+    # set CHECK_MODE if empty, below are check mode values
+    # 1 = check only name, 2 = check name and size, 3 = check name and md5sum
+    [ -z "${CHECK_MODE}" ] && {
+        case "${SKIP_DUPLICATES:-${OVERWRITE}}" in
+            "Overwrite") export CHECK_MODE="1" ;;
+            "Skip Existing") export CHECK_MODE="2" ;;
+        esac
     }
 
     return 0
@@ -606,11 +624,13 @@ EOF
         esac; do
         _print_center "justify" "Given Input" ": ID" "="
         "${EXTRA_LOG}" "justify" "Checking if id exists.." "-"
-        json="$(_drive_info "${gdrive_id}" "name,mimeType,size")" || :
+        [ "${CHECK_MODE}" = "md5Checksum" ] && param="md5Checksum"
+        json="$(_drive_info "${gdrive_id}" "name,mimeType,size${param:+,${param}}")" || :
         if ! printf "%s\n" "${json}" | _json_value code 1 1 2>| /dev/null 1>&2; then
             type="$(printf "%s\n" "${json}" | _json_value mimeType 1 1 || :)"
             name="$(printf "%s\n" "${json}" | _json_value name 1 1 || :)"
             size="$(printf "%s\n" "${json}" | _json_value size 1 1 || :)"
+            [ "${CHECK_MODE}" = "md5Checksum" ] && md5="$(printf "%s\n" "${json}" | _json_value md5Checksum 1 1 || :)"
             for _ in 1 2; do _clear_line 1; done
             case "${type}" in
                 *folder*)
@@ -626,7 +646,7 @@ EOF
 
                     _print_center "justify" "Given Input" ": File ID" "="
                     _print_center "justify" "Upload Method" ": ${SKIP_DUPLICATES:-${OVERWRITE:-Create}}" "=" && _newline "\n"
-                    _clone_file "${UPLOAD_MODE:-create}" "${gdrive_id}" "${WORKSPACE_FOLDER_ID}" "${name}" "${size}" ||
+                    _clone_file "${UPLOAD_MODE:-create}" "${gdrive_id}" "${WORKSPACE_FOLDER_ID}" "${name}" "${size}" "${md5}" ||
                         { for _ in 1 2; do _clear_line 1; done && continue; }
                     ;;
             esac


### PR DESCRIPTION
common-utils.sh: Fix _json_escape function for OSX sed
#
Add new flag --check-mode/-cm

Additional flag for --overwrite and --skip-duplicates flag. Can be used to change check mode in those flags, available args are 'size' and 'md5'.

There should be three modes:

	name
	name and size
	name and md5sum

Default mode for skipping duplicates: name and size

Default mode for overwrite: name
#
Apply some fixes to install.sh