### PR TITLE
Fix not compatible "--" specification problem (BSD versions chmod) | …

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -336,7 +336,7 @@ _variables() {
 _download_file() {
     cd "${INSTALL_PATH}" 2>| /dev/null 1>&2 || exit 1
     # make the file writable if present
-    [ -f "${INSTALL_PATH}/${COMMAND_NAME}" ] && chmod u+w -- "${INSTALL_PATH}/${COMMAND_NAME}"
+    [ -f "${INSTALL_PATH}/${COMMAND_NAME}" ] && chmod -- u+w "${INSTALL_PATH}/${COMMAND_NAME}"
     _print_center "justify" "${COMMAND_NAME}" "-"
     # now download the binary
     if script_download_file="$(curl -Ls --compressed "https://github.com/${REPO}/raw/${LATEST_CURRENT_SHA}/release/${INSTALLATION:-}/gupload")"; then
@@ -350,7 +350,7 @@ _download_file() {
 
     [ -n "${SKIP_SYNC}" ] && return 0
     # make the file writable if present
-    [ -f "${INSTALL_PATH}/${SYNC_COMMAND_NAME}" ] && chmod u+w -- "${INSTALL_PATH}/${SYNC_COMMAND_NAME}"
+    [ -f "${INSTALL_PATH}/${SYNC_COMMAND_NAME}" ] && chmod -- u+w "${INSTALL_PATH}/${SYNC_COMMAND_NAME}"
     _print_center "justify" "${SYNC_COMMAND_NAME}" "-"
     # now download the binary
     if script_download_file="$(curl -Ls --compressed "https://github.com/${REPO}/raw/${LATEST_CURRENT_SHA}/release/${INSTALLATION:-}/gsync")"; then
@@ -418,8 +418,8 @@ _start() {
             exit 1
         fi
 
-        chmod "a-w-r-x,${PERM_MODE:-u}+x+r" -- "${INSTALL_PATH}/${COMMAND_NAME}"
-        chmod "a-w-r-x,${PERM_MODE:-u}+x+r" -- "${INSTALL_PATH}/${SYNC_COMMAND_NAME}"
+        chmod -- "a-w-r-x,${PERM_MODE:-u}+x+r" "${INSTALL_PATH}/${COMMAND_NAME}"
+        chmod -- "a-w-r-x,${PERM_MODE:-u}+x+r" "${INSTALL_PATH}/${SYNC_COMMAND_NAME}"
 
         for _ in 1 2; do _clear_line 1; done
 
@@ -465,11 +465,11 @@ _start() {
 _uninstall() {
     _print_center "justify" "Uninstalling.." "-"
 
-    chmod -f u+w -- "${INSTALL_PATH}/${COMMAND_NAME}"
+    chmod -f -- u+w "${INSTALL_PATH}/${COMMAND_NAME}"
     rm -f -- "${INSTALL_PATH:?}/${COMMAND_NAME:?}"
 
     [ -z "${SKIP_SYNC}" ] && command -v "${SYNC_COMMAND_NAME}" 2>| /dev/null 1>&2 && {
-        chmod -f u+w -- "${INSTALL_PATH}/${SYNC_COMMAND_NAME}"
+        chmod -f -- u+w "${INSTALL_PATH}/${SYNC_COMMAND_NAME}"
         rm -f -- "${INSTALL_PATH:?}/${SYNC_COMMAND_NAME:?}"
     }
 

--- a/src/common/auth-utils.sh
+++ b/src/common/auth-utils.sh
@@ -106,9 +106,9 @@ _delete_account() {
     if _account_exists "${account_delete_account}"; then
         regex_delete_account="^ACCOUNT_${account_delete_account}_(CLIENT_ID=|CLIENT_SECRET=|REFRESH_TOKEN=|ROOT_FOLDER=|ROOT_FOLDER_NAME=|ACCESS_TOKEN=|ACCESS_TOKEN_EXPIRY=)|DEFAULT_ACCOUNT=\"${account_delete_account}\""
         config_without_values_delete_account="$(grep -vE "${regex_delete_account}" -- "${CONFIG}")"
-        chmod u+w -- "${CONFIG}" || return 1 # change perms to edit
+        chmod -- u+w "${CONFIG}" || return 1 # change perms to edit
         printf "%s\n" "${config_without_values_delete_account}" >| "${CONFIG}" || return 1
-        chmod "a-w-r-x,u+r" -- "${CONFIG}" || return 1 # restore perms
+        chmod -- "a-w-r-x,u+r" "${CONFIG}" || return 1 # restore perms
         "${QUIET:-_print_center}" "normal" " Successfully deleted account ( ${account_delete_account} ) from config. " "-"
     else
         "${QUIET:-_print_center}" "normal" " Error: Cannot delete account ( ${account_delete_account} ) from config. No such account exists " "-" 1>&2
@@ -132,7 +132,7 @@ _handle_old_config() {
         done
         regex_check_handle_old_config="^(CLIENT_ID=|CLIENT_SECRET=|REFRESH_TOKEN=|ROOT_FOLDER=|ROOT_FOLDER_NAME=|ACCESS_TOKEN=|ACCESS_TOKEN_EXPIRY=)"
         config_without_values_handle_old_config="$(grep -vE "${regex_check_handle_old_config}" -- "${CONFIG}")"
-        chmod u+w -- "${CONFIG}" || return 1 # change perms to edit
+        chmod -- u+w "${CONFIG}" || return 1 # change perms to edit
         printf "%s\n%s\n%s\n%s\n%s\n%s\n" \
             "ACCOUNT_${account_name_handle_old_config}_CLIENT_ID=\"${CLIENT_ID}\"" \
             "ACCOUNT_${account_name_handle_old_config}_CLIENT_SECRET=\"${CLIENT_SECRET}\"" \
@@ -141,7 +141,7 @@ _handle_old_config() {
             "ACCOUNT_${account_name_handle_old_config}_ROOT_FOLDER_NAME=\"${ROOT_FOLDER_NAME}\"" \
             "${config_without_values_handle_old_config}" >| "${CONFIG}" || return 1
 
-        chmod "a-w-r-x,u+r" -- "${CONFIG}" || return 1 # restore perms
+        chmod -- "a-w-r-x,u+r" "${CONFIG}" || return 1 # restore perms
 
         _reload_config || return 1 # reload config file
     }

--- a/src/common/common-utils.sh
+++ b/src/common/common-utils.sh
@@ -235,8 +235,8 @@ _parse_config() {
 
         # trim the first and last qoute if present on both sides
         case "${val}" in
-            \"*\") val="${val#\"}" val="${val%\"}" ;;
-            \'*\') val="${val#\'}" val="${val%\'}" ;;
+            \"*\") val="${val#\"}" && val="${val%\"}" ;;
+            \'*\') val="${val#\'}" && val="${val%\'}" ;;
             *) : ;;
         esac
 

--- a/src/common/common-utils.sh
+++ b/src/common/common-utils.sh
@@ -407,9 +407,9 @@ _update_config() {
     [ $# -lt 3 ] && printf "Missing arguments\n" && return 1
     value_name_update_config="${1}" value_update_config="${2}" config_path_update_config="${3}"
     ! [ -f "${config_path_update_config}" ] && : >| "${config_path_update_config}" # If config file doesn't exist.
-    chmod u+w -- "${config_path_update_config}" || return 1
+    chmod -- u+w "${config_path_update_config}" || return 1
     printf "%s\n%s\n" "$(grep -v -e "^$" -e "^${value_name_update_config}=" -- "${config_path_update_config}" || :)" \
         "${value_name_update_config}=\"${value_update_config}\"" >| "${config_path_update_config}" || return 1
-    chmod a-w-r-x,u+r -- "${config_path_update_config}" || return 1
+    chmod -- a-w-r-x,u+r "${config_path_update_config}" || return 1
     return 0
 }

--- a/src/common/drive-utils.sh
+++ b/src/common/drive-utils.sh
@@ -73,8 +73,8 @@ _clone_file() {
     if [ "${job_clone_file}" = update ]; then
         unset file_check_json_clone_file check_value_type_clone_file check_value_clone_file
         case "${CHECK_MODE}" in
-            2) check_value_type_clone_file="size" check_value_clone_file="${size_clone_file}" ;;
-            3) check_value_type_clone_file="md5Checksum" check_value_clone_file="${md5_clone_file}" ;;
+            2) check_value_type_clone_file="size" && check_value_clone_file="${size_clone_file}" ;;
+            3) check_value_type_clone_file="md5Checksum" && check_value_clone_file="${md5_clone_file}" ;;
             *) : ;;
         esac
         # Check if file actually exists.
@@ -249,7 +249,7 @@ _upload_file() {
     [ "${job_upload_file}" = update ] && {
         unset file_check_json_upload_file check_value_upload_file
         case "${CHECK_MODE}" in
-            2) check_value_type_upload_file="size" check_value_upload_file="${inputsize_upload_file}" ;;
+            2) check_value_type_upload_file="size" && check_value_upload_file="${inputsize_upload_file}" ;;
             3)
                 check_value_type_upload_file="md5Checksum"
                 check_value_upload_file="$(md5sum "${input_upload_file}")" || {

--- a/src/common/update.sh
+++ b/src/common/update.sh
@@ -68,6 +68,6 @@ _update_value() {
         printf "%s\n" "Update downloaded but malformed, try again and if the issue persists open an issue on github."
         return 1
     }
-    chmod u+w -- "${command_path}" && printf "%s\n" "${new_script}" >| "${command_path}" && chmod "a-w-r-x,${PERM_MODE:-u}+r+x" -- "${command_path}"
+    chmod -- u+w "${command_path}" && printf "%s\n" "${new_script}" >| "${command_path}" && chmod -- "a-w-r-x,${PERM_MODE:-u}+r+x" "${command_path}"
     return 0
 }

--- a/src/common/upload-common.sh
+++ b/src/common/upload-common.sh
@@ -24,9 +24,9 @@ _cleanup_config() {
 $(grep -F ACCESS_TOKEN_EXPIRY -- "${config}" || :)
 EOF
 
-    chmod u+w -- "${config}" &&
+    chmod -- u+w "${config}" &&
         printf "%s\n" "$(grep -Ev "^\$${values_regex:+|${values_regex}}" -- "${config}")" >| "${config}" &&
-        chmod "a-w-r-x,u+r" -- "${config}"
+        chmod -- "a-w-r-x,u+r" "${config}"
     return 0
 }
 


### PR DESCRIPTION
…fix #195

43c75ff ```add a -- flag, to treat all input as file or folder or drive id input``` bug.

```
BSD versions chmod (strict arguments parser)
$ chmod {mode} -- {file} <-- NG (change permission "--" file)
$ chmod -- {mode} {file} <-- OK ({option} arguments not used)
```

See chmod synopsis and utility syntax guideline 10.
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/chmod.html#tag_20_17_02
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02